### PR TITLE
A basic runtime library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,16 +11,15 @@ add_definitions(
   -Wall
   -Wextra
   -Werror
-  -std=c++14
   -Wno-unused-function # Stupid flex.
   -Wno-unused-parameter # Maphoon's fault
   -Wno-sign-compare     # Maphoon's fault
   -g
   -rdynamic
- # -fno-rtti
   )
 
 find_package(FLEX REQUIRED)
 find_package(LLVM REQUIRED)
 
 add_subdirectory(src)
+add_subdirectory(libcco)

--- a/libcco/CMakeLists.txt
+++ b/libcco/CMakeLists.txt
@@ -1,0 +1,18 @@
+file(GLOB SOURCES
+  ./*.c
+  )
+
+add_library(libcco STATIC
+  ${SOURCES}
+  )
+
+set_target_properties(libcco PROPERTIES OUTPUT_NAME libcco)
+
+# Disables the addition of one more "lib" prefix on libcco
+SET_TARGET_PROPERTIES(libcco PROPERTIES PREFIX "")
+
+# Copy the final lib to outside libcco dir
+add_custom_command(
+  TARGET libcco POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/libcco${CMAKE_STATIC_LIBRARY_SUFFIX}" "${CMAKE_BINARY_DIR}/"
+  )

--- a/libcco/print.c
+++ b/libcco/print.c
@@ -1,0 +1,13 @@
+#include "print.h"
+#include <stdio.h>
+
+void __cco_print_int(int v){
+    printf("%d\n",v);
+}
+void __cco_print_double(double v){
+    printf("%f\n",v);
+}
+void __cco_print_bool(int v){
+    if(v) printf("True\n");
+    else  printf("False\n");
+}

--- a/libcco/print.h
+++ b/libcco/print.h
@@ -1,0 +1,12 @@
+#ifndef __CCO_PRINT_H__
+#define __CCO_PRINT_H__
+
+// Eventually, these definitions will have to be wrapped in macros, so
+// that they can either define these functions, or unwrap into a C++
+// code that inserts their prototypes to the llvm::Module.
+
+void __cco_print_int(int);
+void __cco_print_double(double);
+void __cco_print_bool(int);
+
+#endif // __CCO_PRINT_H__

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,11 @@
 include(ExternalProject)
 
-# Helper function
+add_definitions(
+  -std=c++14
+ # -fno-rtti
+  )
 
+# Helper function
 function(prepend list prefix)
    set(tmpvar "")
    foreach(x ${ARGN})

--- a/src/codegencontext.h
+++ b/src/codegencontext.h
@@ -54,7 +54,7 @@ struct TypeHash { size_t operator () (const TypeAST* t) const { return 1; } };
 struct TypeEqual {
     bool operator () (const TypeAST* t1, const TypeAST* t2) const {
         return t1->equal(*t2);
-    } 
+    }
 };
 
 using TypeSet = std::unordered_set<const TypeAST*, TypeHash, TypeEqual>;
@@ -69,17 +69,17 @@ class CodegenContext
 public:
     CodegenContext();
     ~CodegenContext();
-    
+
     // ==---------------------------------------------------------------
     // Factory methods for AST nodes
-    
+
     VariableExpr makeVariable(std::string name);
     PrimitiveExpr<int> makeInt(int value);
     PrimitiveExpr<double> makeDouble(double value);
     PrimitiveExpr<bool> makeBool(bool value);
     BinaryExpr makeBinary(std::string Op, Expr LHS, Expr RHS);
     ReturnExpr makeReturn(Expr expr);
-    Block makeBlock(const std::vector<std::pair<std::string, Type>> &vars, 
+    Block makeBlock(const std::vector<std::pair<std::string, Type>> &vars,
                     const std::list<Expr>& s);
     Assignment makeAssignment(const std::string& Name, Expr expr);
     CallExpr makeCall(const std::string &Callee, std::vector<Expr> Args);
@@ -87,36 +87,36 @@ public:
     WhileExpr makeWhile(Expr Cond, Expr Body);
     ForExpr makeFor(Expr Init, Expr Cond, std::list<Expr> Step, Expr Body);
     Keyword makeKeyword(keyword which);
-    Prototype makePrototype(const std::string &Name, 
+    Prototype makePrototype(const std::string &Name,
         std::vector<std::pair<std::string, Type>> Args, Type ReturnType);
     Function makeFunction(Prototype Proto, Expr Body);
-    
+
     // ==---------------------------------------------------------------
-    
+
     // ==---------------------------------------------------------------
     // Factory methods for Types
-    
+
     VoidType getVoidTy();
     IntegerType getIntegerTy();
     DoubleType getDoubleTy();
     BooleanType getBooleanTy();
     FunctionType getFunctionTy(Type ret, std::vector<Type> args);
     ReferenceType getReferenceTy(Type of);
-    
+
     // ==---------------------------------------------------------------
-    
+
     mutable GIDSet<FunctionAST> definitions;
     mutable GIDSet<PrototypeAST> prototypes;
     mutable std::map<std::string, Prototype> prototypesMap;
     mutable GIDSet<ExprAST> expressions;
     mutable TypeSet types;
-    
+
     std::shared_ptr<llvm::Module> TheModule;
     llvm::IRBuilder<> Builder;
     llvm::Function* CurrentFunc;
     mutable std::map<std::string, std::pair<llvm::AllocaInst*, Type>> VarsInScope;
-    
-    std::map<std::tuple<std::string, Type, Type>, 
+
+    std::map<std::tuple<std::string, Type, Type>,
             std::pair<std::function<llvm::Value*(llvm::Value*, llvm::Value*)>,
                       Type>,
             TTypeCmp> BinOpCreator;
@@ -128,8 +128,8 @@ public:
     bool is_inside_loop () const { return !LoopsBBHeaderPost.empty(); }
 
     // Special function handles
-    llvm::Function* func_printf;
-    
+    llvm::Function* GetStdFunction(std::string name) const;
+
     void SetModuleAndFile(std::shared_ptr<llvm::Module> module, std::string infile);
 
     // Stores an error-message. TODO: Add file positions storage.
@@ -145,9 +145,14 @@ protected:
     // Storage for error messages.
     mutable std::list<std::pair<std::string, std::string>> errors;
 
+    // The map storing special function handlers, use GetStdFunctions to search for a handle.
+    std::map<std::string, llvm::Function*> stdlib_functions;
+    // Initializes the above map, called as soon as a module is set.
+    void PrepareStdFunctionPrototypes();
+
     // The base input source file for this module
     std::string filename;
-    
+
     // Is there a way to merge these two "introduces"? TODO: find a way!
     template<class T>
     const T* introduceE(const T* node) { return introduce_expr(node)->template as<T>(); }
@@ -157,7 +162,7 @@ protected:
     const TypeAST* introduce_type(const TypeAST*);
     const PrototypeAST* introduce_prototype(const PrototypeAST*);
     const FunctionAST* introduce_function(const FunctionAST*);
-    
+
     mutable size_t gid_;
 };
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -36,22 +36,9 @@ bool WasParserSuccessful(tokenizer& tok){\
     }
 }
 
-void DeclareCFunctions(CodegenContext& ctx){
-    using namespace llvm;
-    
-    std::vector<llvm::Type *> putchar_args = {llvm::Type::getInt32Ty(getGlobalContext())};
-    auto putchar_type = llvm::FunctionType::get(llvm::Type::getInt32Ty(getGlobalContext()), putchar_args, false);
-    llvm::Function::Create(putchar_type, llvm::Function::ExternalLinkage, "putchar", ctx.TheModule.get());
-
-
-    auto printf_type = TypeBuilder<int(char *, ...), false>::get(getGlobalContext());
-    auto f = llvm::Function::Create(printf_type, llvm::Function::ExternalLinkage, "printf", ctx.TheModule.get());
-    ctx.func_printf = f;
-}
-
 std::shared_ptr<llvm::legacy::FunctionPassManager> PreparePassManager(llvm::Module * m, unsigned int lvl){
     using namespace llvm;
-    
+
     // Create a new pass manager attached to it.
     auto TheFPM = std::make_shared<legacy::FunctionPassManager>(m);
 
@@ -78,7 +65,7 @@ std::shared_ptr<llvm::legacy::FunctionPassManager> PreparePassManager(llvm::Modu
 
 int Compile(std::string infile, std::string outfile, unsigned int optlevel){
     using namespace llvm;
-    
+
     if(!FileExists(infile)){
         std::cout << "File " << infile << " does not exist." << std::endl;
         return -1;
@@ -88,11 +75,11 @@ int Compile(std::string infile, std::string outfile, unsigned int optlevel){
     tok.prepare(infile);
 
     std::cout << ColorStrings::Color(Color::Cyan, true) << "Parsing " << infile << ColorStrings::Reset() << std::endl;
-    
+
     auto ctx = CodegenContext{};
-    
+
     parser(tok, ctx, /*prototypes,definitions, */tkn_Start, 0);
-    
+
     // Instead of returning an exit status, the parser returns
     // nothing, and we need to determine if parsing was successful by
     // examining the lookahead buffer.
@@ -104,12 +91,10 @@ int Compile(std::string infile, std::string outfile, unsigned int optlevel){
     std::cout << "Found " << ctx.prototypes.size() << " prototypes and " << ctx.definitions.size() << " function definitions. " << std::endl;
 
     auto module = std::make_shared<Module>("CCoscope compiler", getGlobalContext());
-    
-    ctx.SetModuleAndFile(module, infile);
-    
-    auto TheFPM = PreparePassManager(ctx.TheModule.get(), optlevel);
 
-    DeclareCFunctions(ctx);
+    ctx.SetModuleAndFile(module, infile);
+
+    auto TheFPM = PreparePassManager(ctx.TheModule.get(), optlevel);
 
     bool errors = false;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.h"
 #include <fstream>
 #include <iostream>
+#include <unistd.h>
 
 bool FileExists(std::string name)
 {
@@ -17,6 +18,16 @@ std::string GetTmpFile(std::string suffix){
      * file descriptor.  And I need a file name to pass to
      * subprocesses. There is no other way to get such name.  */
     return tmpnam(nullptr) + suffix;
+}
+
+std::string GetExecutablePath(){
+    // The trick is to read what file the link /proc/self/exe points to.
+    // This is obviously not portable.
+    char buffer[260];
+    readlink("/proc/self/exe",buffer,260);
+    std::string path(buffer);
+    auto pos = path.rfind('/');
+    return path.substr(0,pos+1);
 }
 
 void CopyFile(std::string src, std::string dest){

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,6 +6,8 @@
 
 bool FileExists(std::string name);
 std::string GetTmpFile(std::string suffix = "");
+// Returns the path to CCoscope executable
+std::string GetExecutablePath();
 
 void CopyFile(std::string src, std::string dest);
 std::string SubstFileExt(std::string filename, std::string ext);


### PR DESCRIPTION
This branch introduces a simple runtime library, that currently provides just implementations for different print functions, so that the compiled does not have to reference printf directly. Any produced binary is linked with that library, unless `-no-stdlib` is specified at command line.

The diff also includes the removal of many trailing whitespaces. If for any reason you cannot configure your editor to clean them automatically, we may use `astyle` to clean up the source files for us in a uniform style.
