### PR TITLE
Binary operator resolution and implicit type conversions

### DIFF
--- a/examples/carpet.cco
+++ b/examples/carpet.cco
@@ -48,3 +48,4 @@ fun draw_frac(max : int, cur_y : int, cur_x : int, depth : int) : bool {
     }
     return true;
 }
+

--- a/examples/complex.cco
+++ b/examples/complex.cco
@@ -1,0 +1,13 @@
+
+fun main() : int {
+    var i : int;
+    var f1 : double;
+    var f2 : double;
+    var c : complex;
+    
+    f1 := 3.14;
+    f2 := -2;
+    c := newComplex(f1, f2);
+    print(f1);
+    print(f2);
+}

--- a/examples/complex.cco
+++ b/examples/complex.cco
@@ -1,4 +1,8 @@
 
+fun foo(Re : double, Im : double) : double {
+    return Re;
+}
+
 fun main() : int {
     var i : int;
     var f1 : double;

--- a/examples/complex.cco
+++ b/examples/complex.cco
@@ -1,7 +1,4 @@
 
-fun foo(Re : double, Im : double) : double {
-    return Re;
-}
 
 fun main() : int {
     var i : int;

--- a/examples/complex.cco
+++ b/examples/complex.cco
@@ -11,4 +11,5 @@ fun main() : int {
     c := newComplex(f1, f2);
     print(f1);
     print(f2);
+    print(c);
 }

--- a/examples/complex2.cco
+++ b/examples/complex2.cco
@@ -1,0 +1,26 @@
+
+fun foo(a : complex, b : complex) : complex {
+  var c : complex;
+  c := a + b * a;
+  return c;
+}
+
+fun bar(a : int, b : double) : complex {
+  var g : double;
+  g := 2 * a + b;
+  return g;
+  //return newComplex(g, 0);
+}
+
+fun main() : int {
+    var i : int;
+    var c : complex;
+    var d : complex;
+    
+    c := newComplex(3, -2);
+    d := foo(-2, c);
+    print(d);
+    d := bar(3, 0.14);
+    print(d);
+    print(bar(3, 0.14));
+}

--- a/examples/complex_arith.cco
+++ b/examples/complex_arith.cco
@@ -5,6 +5,7 @@ fun main() : int {
     var f2 : double;
     var c1 : complex;
     var c2 : complex;
+    var c3 : complex;
     var cres : complex;
     
     f1 := 3.14;
@@ -16,10 +17,14 @@ fun main() : int {
     print(c2);
     cres := c1 + c2;
     print(cres);
+    c3 := newComplex(8.14, 4.66);
+    print(cres == c3);
+    c3 := newComplex(8.140, 4.6601);
+    print(cres == c3);
     cres := c1 - c2;
     print(cres);
     cres := c1 * c2;
     print(cres);
-    //cres := c1 / c2;
-    //print(cres);
+    cres := c1 / c2;
+    print(cres);
 }

--- a/examples/complex_arith.cco
+++ b/examples/complex_arith.cco
@@ -1,0 +1,25 @@
+
+fun main() : int {
+    var i : int;
+    var f1 : double;
+    var f2 : double;
+    var c1 : complex;
+    var c2 : complex;
+    var cres : complex;
+    
+    f1 := 3.14;
+    f2 := -2;
+    c1 := newComplex(f1, f2);
+    i := 5;
+    c2 := newComplex(5, 6.66);
+    print(c1);
+    print(c2);
+    cres := c1 + c2;
+    print(cres);
+    cres := c1 - c2;
+    print(cres);
+    cres := c1 * c2;
+    print(cres);
+    //cres := c1 / c2;
+    //print(cres);
+}

--- a/examples/continue.cco
+++ b/examples/continue.cco
@@ -5,6 +5,7 @@ fun main() : int {
         a := a - 1;
         if (a % 2 == 0) {
             continue;
+            a := a+2;
         }
         print(a);
     }

--- a/examples/implicit.cco
+++ b/examples/implicit.cco
@@ -15,5 +15,6 @@ fun main() : int{
     print(x);
     print(3.12 + 3);
 
+
     return 0;
 }

--- a/examples/implicit.cco
+++ b/examples/implicit.cco
@@ -1,0 +1,19 @@
+// This file tests some basic implicit conversions
+
+fun main() : int{
+    var d : double;
+    var i : int;
+    var x : double;
+
+    d := 1.12;
+    d := d + 2;
+
+    i := 3;
+
+    x := d + i;
+
+    print(x);
+    print(3.12 + 3);
+
+    return 0;
+}

--- a/examples/implicit_call.cco
+++ b/examples/implicit_call.cco
@@ -1,0 +1,14 @@
+fun do_sth_with_double(x : double) : double{
+    var p : int;
+    print(x);
+    p := 10;
+    return p; // Implicit conversion in return statement
+}
+fun main() : int{
+    var a : int;
+    var b : double;
+    a := 4;
+    b := do_sth_with_double(a); // Implicit conversion within call
+    print(b);
+    return 0;
+}

--- a/examples/reftest.cco
+++ b/examples/reftest.cco
@@ -2,7 +2,7 @@ fun main() : int{
     var x : int;
     var y : int;
     x := 5;
-    y := x;
+    y := x + 5;
     print(y);
     return 0;
 }

--- a/examples/reftest.cco
+++ b/examples/reftest.cco
@@ -3,6 +3,6 @@ fun main() : int{
     var y : int;
     x := 5;
     y := x;
-    //print(x);
+    print(y);
     return 0;
 }

--- a/examples/reftest.cco
+++ b/examples/reftest.cco
@@ -1,0 +1,6 @@
+fun main() : int{
+    var x : int;
+    x := 5;
+    print(x);
+    return 0;
+}

--- a/examples/reftest.cco
+++ b/examples/reftest.cco
@@ -1,6 +1,8 @@
 fun main() : int{
     var x : int;
+    var y : int;
     x := 5;
-    print(x);
+    y := x;
+    //print(x);
     return 0;
 }

--- a/libcco/print.c
+++ b/libcco/print.c
@@ -11,3 +11,11 @@ void __cco_print_bool(int v){
     if(v) printf("True\n");
     else  printf("False\n");
 }
+
+void __cco_print_cstr(char* v) {
+    printf("%s\n", v);
+}
+
+void __cco_print_complex(double re, double im) {
+    printf("Complex[Re = %f; Im = %f]\n", re, im);
+}

--- a/libcco/print.h
+++ b/libcco/print.h
@@ -8,5 +8,7 @@
 void __cco_print_int(int);
 void __cco_print_double(double);
 void __cco_print_bool(int);
+void __cco_print_cstr(char*);
+void __cco_print_complex(double, double);
 
 #endif // __CCO_PRINT_H__

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -73,8 +73,6 @@ CodegenContext::CodegenContext()
     ADD_BASIC_OP("GREATEREQ",getDoubleTy(), getDoubleTy(), CreateFCmpOGE, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("LESS",     getDoubleTy(), getDoubleTy(), CreateFCmpOLT, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("LESSEQ",   getDoubleTy(), getDoubleTy(), CreateFCmpOLE, getBooleanTy(), "cmptmp");
-
-    typematcher.InitImplicitConversions();
 }
 
 CodegenContext::~CodegenContext() {

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -354,17 +354,16 @@ void CodegenContext::PrepareStdFunctionPrototypes(){
     ADD_STDPROTO("print_double",void(double));
     ADD_STDPROTO("print_bool",void(llvm::types::i<1>));
     
-    auto blafun = makeFunction(makePrototype(
-        "bla", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getDoubleTy()),
-        makeReturn((makeVariable("Re")))
+    auto blaproto = makePrototype(
+        "bla", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getDoubleTy());
+    makeFunction(blaproto, makeBlock({}, {makeReturn((makeVariable("Re")))})
         );
-    blafun->codegen();
     
-    auto complexfun = makeFunction(makePrototype(
-        "newComplex", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getComplexTy()),
-        makeReturn(makeComplex(makeVariable("Re"), makeVariable("Im")))
+    auto complexproto = makePrototype(
+        "newComplex", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getComplexTy());
+    makeFunction(complexproto, makeBlock({},
+        {makeReturn(makeComplex(makeVariable("Re"), makeVariable("Im")))})
         );
-    complexfun->codegen();
 }
 
 

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -354,11 +354,6 @@ void CodegenContext::PrepareStdFunctionPrototypes(){
     ADD_STDPROTO("print_double",void(double));
     ADD_STDPROTO("print_bool",void(llvm::types::i<1>));
     
-    auto blaproto = makePrototype(
-        "bla", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getDoubleTy());
-    makeFunction(blaproto, makeBlock({}, {makeReturn((makeVariable("Re")))})
-        );
-    
     auto complexproto = makePrototype(
         "newComplex", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getComplexTy());
     makeFunction(complexproto, makeBlock({{"Cmplx", getComplexTy()}},

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -355,7 +355,7 @@ void CodegenContext::PrepareStdFunctionPrototypes(){
     ADD_STDPROTO("print_bool",void(llvm::types::i<1>));
     ADD_STDPROTO("print_cstr", void(char*));
     ADD_STDPROTO("print_complex", void(double, double));
-    
+
     auto complexproto = makePrototype(
         "newComplex", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getComplexTy());
     makeFunction(complexproto, makeBlock({{"Cmplx", getComplexTy()}},

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -168,27 +168,27 @@ Function CodegenContext::makeFunction(Prototype Proto, Expr Body) {
 // ==---------------------------------------------------------------
 // Factory methods for Types
 
-VoidType CodegenContext::getVoidTy() {
+VoidType CodegenContext::getVoidTy() const{
     return introduceT(new VoidTypeAST(*this, gid_++));
 }
 
-IntegerType CodegenContext::getIntegerTy() {
+IntegerType CodegenContext::getIntegerTy() const{
     return introduceT(new IntegerTypeAST(*this, gid_++));
 }
 
-DoubleType CodegenContext::getDoubleTy() {
+DoubleType CodegenContext::getDoubleTy() const{
     return introduceT(new DoubleTypeAST(*this, gid_++));
 }
 
-BooleanType CodegenContext::getBooleanTy() {
+BooleanType CodegenContext::getBooleanTy() const{
     return introduceT(new BooleanTypeAST(*this, gid_++));
 }
 
-FunctionType CodegenContext::getFunctionTy(Type ret, std::vector<Type> args) {
+FunctionType CodegenContext::getFunctionTy(Type ret, std::vector<Type> args) const{
     return introduceT(new FunctionTypeAST(*this, gid_++, ret, args));
 }
 
-ReferenceType CodegenContext::getReferenceTy(Type of) {
+ReferenceType CodegenContext::getReferenceTy(Type of) const{
     return introduceT(new ReferenceTypeAST(*this, gid_++, of));
 }
 
@@ -214,7 +214,7 @@ void CodegenContext::DisplayErrors(){
     }
 }
 
-const ExprAST* CodegenContext::introduce_expr(const ExprAST* node) {
+const ExprAST* CodegenContext::introduce_expr(const ExprAST* node) const{
     /* This look ridiculously simple now, but in the future we can
      * make CSE optimization here
      */
@@ -222,7 +222,7 @@ const ExprAST* CodegenContext::introduce_expr(const ExprAST* node) {
     return node;
 }
 
-const TypeAST* CodegenContext::introduce_type(const TypeAST* node) {
+const TypeAST* CodegenContext::introduce_type(const TypeAST* node) const{
     auto it = types.find(node);
     if(it != types.end() && *it != node) {
         delete node;
@@ -233,7 +233,7 @@ const TypeAST* CodegenContext::introduce_type(const TypeAST* node) {
     return node;
 }
 
-const PrototypeAST* CodegenContext::introduce_prototype(const PrototypeAST* node) {
+const PrototypeAST* CodegenContext::introduce_prototype(const PrototypeAST* node) const{
     auto pit = prototypesMap.find(node->getName());
     if(pit != prototypesMap.end()) {
         delete node;
@@ -245,7 +245,7 @@ const PrototypeAST* CodegenContext::introduce_prototype(const PrototypeAST* node
     return node;
 }
 
-const FunctionAST* CodegenContext::introduce_function(const FunctionAST* node) {
+const FunctionAST* CodegenContext::introduce_function(const FunctionAST* node) const{
     definitions.insert(node);
     return node;
 }

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -312,7 +312,6 @@ const FunctionAST* CodegenContext::introduce_function(const FunctionAST* node) c
     return node;
 }
 
-
 llvm::Function* CodegenContext::GetStdFunction(std::string name) const{
     auto it = stdlib_functions.find(name);
     if(it == stdlib_functions.end()) return nullptr;

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -353,6 +353,8 @@ void CodegenContext::PrepareStdFunctionPrototypes(){
     ADD_STDPROTO("print_int",void(int));
     ADD_STDPROTO("print_double",void(double));
     ADD_STDPROTO("print_bool",void(llvm::types::i<1>));
+    ADD_STDPROTO("print_cstr", void(char*));
+    ADD_STDPROTO("print_complex", void(double, double));
     
     auto complexproto = makePrototype(
         "newComplex", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getComplexTy());

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -361,7 +361,7 @@ void CodegenContext::PrepareStdFunctionPrototypes(){
     
     auto complexproto = makePrototype(
         "newComplex", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getComplexTy());
-    makeFunction(complexproto, makeBlock({},
+    makeFunction(complexproto, makeBlock({{"Cmplx", getComplexTy()}},
         {makeReturn(makeComplex(makeVariable("Re"), makeVariable("Im")))})
         );
 }

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -21,13 +21,13 @@ CodegenContext::CodegenContext()
     // Operators on integers
 
 
-#define INIT_OP(name) BinOpCreator[name] = std::list<OperatorEntry>()
+#define INIT_OP(name) BinOpCreator[name] = std::list<MatchCandidateEntry>()
 
-#define ADD_BASIC_OP(name, t1, t2, builderfunc, rettype, retname)\
-    BinOpCreator[name].push_back(OperatorEntry{t1, t2,           \
-       [this] (Value* LHS, Value* RHS) {                         \
-           return this->Builder.builderfunc(LHS, RHS, retname);  \
-       }, rettype                                                \
+#define ADD_BASIC_OP(name, t1, t2, builderfunc, rettype, retname) \
+    BinOpCreator[name].push_back(MatchCandidateEntry{{t1, t2},    \
+       [this] (std::vector<Value*> v){                            \
+            return this->Builder.builderfunc(v[0], v[1], retname);\
+       }, rettype                                                 \
     })
 
     // We wouldn't need that if STL provided a `defaultdict`.

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -73,73 +73,45 @@ CodegenContext::CodegenContext()
     ADD_BASIC_OP("LESS",     getDoubleTy(), getDoubleTy(), CreateFCmpOLT, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("LESSEQ",   getDoubleTy(), getDoubleTy(), CreateFCmpOLE, getBooleanTy(), "cmptmp");
 
-    BinOpCreator["ADD"].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()},
-       [this] (std::vector<Value*> v){
-            auto c1re = this->Builder.CreateExtractValue(v[0], {0});
-            auto c1im = this->Builder.CreateExtractValue(v[0], {1});
-            auto c2re = this->Builder.CreateExtractValue(v[1], {0});
-            auto c2im = this->Builder.CreateExtractValue(v[1], {1});
+#define ADD_COMPLEX_OP(name, variadiccode, rettype, retname) \
+    BinOpCreator[name].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()},    \
+       [this] (std::vector<Value*> v){                            \
+            auto c1re = this->Builder.CreateExtractValue(v[0], {0}); \
+            auto c1im = this->Builder.CreateExtractValue(v[0], {1}); \
+            auto c2re = this->Builder.CreateExtractValue(v[1], {0}); \
+            auto c2im = this->Builder.CreateExtractValue(v[1], {1}); \
+            variadiccode \
+            auto cmplx_t = getComplexTy()->toLLVMs(); \
+            AllocaInst* alloca = CreateEntryBlockAlloca(CurrentFunc, "cmplxtmp", cmplx_t); \
+            auto idx1 = this->Builder.CreateStructGEP(cmplx_t, alloca, 0); \
+            this->Builder.CreateStore(reres, idx1); \
+            auto idx2 = this->Builder.CreateStructGEP(cmplx_t, alloca, 1); \
+            this->Builder.CreateStore(imres, idx2); \
+            auto retsload = this->Builder.CreateLoad(alloca, "Cmplxloadret"); \
+            return retsload; \
+       }, rettype                                                 \
+    })
+
+    ADD_COMPLEX_OP("ADD",
             auto reres = this->Builder.CreateFAdd(c1re, c2re, "cmplxaddtmp");
             auto imres = this->Builder.CreateFAdd(c1im, c2im, "cmplxaddtmp");
-            auto cmplx_t = getComplexTy()->toLLVMs();
-            AllocaInst* alloca = CreateEntryBlockAlloca(CurrentFunc, "cmplxtmp", cmplx_t);
-            auto idx1 = this->Builder.CreateStructGEP(cmplx_t, alloca, 0);
-            this->Builder.CreateStore(reres, idx1);
-            auto idx2 = this->Builder.CreateStructGEP(cmplx_t, alloca, 1);
-            this->Builder.CreateStore(imres, idx2);
-            auto retsload = this->Builder.CreateLoad(alloca, "Cmplxloadret");
-            return retsload;
-       }, getComplexTy()
-    });
+     , getComplexTy(), "addtmp");
 
-    BinOpCreator["SUB"].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()},
-       [this] (std::vector<Value*> v){
-            auto c1re = this->Builder.CreateExtractValue(v[0], {0});
-            auto c1im = this->Builder.CreateExtractValue(v[0], {1});
-            auto c2re = this->Builder.CreateExtractValue(v[1], {0});
-            auto c2im = this->Builder.CreateExtractValue(v[1], {1});
+    ADD_COMPLEX_OP("SUB",
             auto reres = this->Builder.CreateFSub(c1re, c2re, "cmplxsubtmp");
             auto imres = this->Builder.CreateFSub(c1im, c2im, "cmplxsubtmp");
-            auto cmplx_t = getComplexTy()->toLLVMs();
-            AllocaInst* alloca = CreateEntryBlockAlloca(CurrentFunc, "cmplxtmp", cmplx_t);
-            auto idx1 = this->Builder.CreateStructGEP(cmplx_t, alloca, 0);
-            this->Builder.CreateStore(reres, idx1);
-            auto idx2 = this->Builder.CreateStructGEP(cmplx_t, alloca, 1);
-            this->Builder.CreateStore(imres, idx2);
-            auto retsload = this->Builder.CreateLoad(alloca, "Cmplxloadret");
-            return retsload;
-       }, getComplexTy()
-    });
+     , getComplexTy(), "subtmp");
 
-    BinOpCreator["MULT"].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()},
-       [this] (std::vector<Value*> v){
-            auto c1re = this->Builder.CreateExtractValue(v[0], {0});
-            auto c1im = this->Builder.CreateExtractValue(v[0], {1});
-            auto c2re = this->Builder.CreateExtractValue(v[1], {0});
-            auto c2im = this->Builder.CreateExtractValue(v[1], {1});
+    ADD_COMPLEX_OP("MULT",
             auto c1c2re = this->Builder.CreateFMul(c1re, c2re, "cmplxmultmp");
             auto c1c2im = this->Builder.CreateFMul(c1im, c2im, "cmplxmultmp");
             auto c1imc2re = this->Builder.CreateFMul(c1im, c2re, "cmplxmultmp");
             auto c1rec2im = this->Builder.CreateFMul(c1re, c2im, "cmplxmultmp");
             auto reres = this->Builder.CreateFSub(c1c2re, c1c2im, "cmplxsubtmp");
             auto imres = this->Builder.CreateFAdd(c1imc2re, c1rec2im, "cmplxaddtmp");
-            auto cmplx_t = getComplexTy()->toLLVMs();
-            AllocaInst* alloca = CreateEntryBlockAlloca(CurrentFunc, "cmplxtmp", cmplx_t);
-            auto idx1 = this->Builder.CreateStructGEP(cmplx_t, alloca, 0);
-            this->Builder.CreateStore(reres, idx1);
-            auto idx2 = this->Builder.CreateStructGEP(cmplx_t, alloca, 1);
-            this->Builder.CreateStore(imres, idx2);
-            auto retsload = this->Builder.CreateLoad(alloca, "Cmplxloadret");
-            return retsload;
-       }, getComplexTy()
-    });
+     , getComplexTy(), "multmp");
 
-    BinOpCreator["DIV"].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()},
-       [this] (std::vector<Value*> v){
-            auto c1re = this->Builder.CreateExtractValue(v[0], {0});
-            auto c1im = this->Builder.CreateExtractValue(v[0], {1});
-            auto c2re = this->Builder.CreateExtractValue(v[1], {0});
-            auto c2im = this->Builder.CreateExtractValue(v[1], {1});
+    ADD_COMPLEX_OP("DIV",
             auto c1c2re = this->Builder.CreateFMul(c1re, c2re, "cmplxmultmp");
             auto c1c2im = this->Builder.CreateFMul(c1im, c2im, "cmplxmultmp");
             auto c1imc2re = this->Builder.CreateFMul(c1im, c2re, "cmplxmultmp");
@@ -151,16 +123,7 @@ CodegenContext::CodegenContext()
             auto right = this->Builder.CreateFSub(c1imc2re, c1rec2im, "cmplxaddtmp");
             auto reres = this->Builder.CreateFDiv(left, squares, "cmplxdivtmp");
             auto imres = this->Builder.CreateFDiv(right, squares, "cmplxdivtmp");
-            auto cmplx_t = getComplexTy()->toLLVMs();
-            AllocaInst* alloca = CreateEntryBlockAlloca(CurrentFunc, "cmplxtmp", cmplx_t);
-            auto idx1 = this->Builder.CreateStructGEP(cmplx_t, alloca, 0);
-            this->Builder.CreateStore(reres, idx1);
-            auto idx2 = this->Builder.CreateStructGEP(cmplx_t, alloca, 1);
-            this->Builder.CreateStore(imres, idx2);
-            auto retsload = this->Builder.CreateLoad(alloca, "Cmplxloadret");
-            return retsload;
-       }, getComplexTy()
-    });
+     , getComplexTy(), "divtmp");
 
     BinOpCreator["EQUAL"].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()},
        [this] (std::vector<Value*> v){

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -73,6 +73,8 @@ CodegenContext::CodegenContext()
     ADD_BASIC_OP("GREATEREQ",getDoubleTy(), getDoubleTy(), CreateFCmpOGE, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("LESS",     getDoubleTy(), getDoubleTy(), CreateFCmpOLT, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("LESSEQ",   getDoubleTy(), getDoubleTy(), CreateFCmpOLE, getBooleanTy(), "cmptmp");
+
+    typematcher.InitImplicitConversions();
 }
 
 CodegenContext::~CodegenContext() {
@@ -86,16 +88,6 @@ CodegenContext::~CodegenContext() {
         delete it;
 }
 
-bool TTypeCmp::operator () (const std::tuple<std::string, Type, Type>& lhs,
-                      const std::tuple<std::string, Type, Type>& rhs) const {
-    return  std::get<0>(lhs) < std::get<0>(rhs) ||
-           (std::get<0>(lhs) == std::get<0>(rhs) &&
-            std::get<1>(lhs)->gid() < std::get<1>(rhs)->gid()) ||
-           (std::get<0>(lhs) == std::get<0>(rhs) &&
-            std::get<1>(lhs)->gid() == std::get<1>(rhs)->gid() &&
-            std::get<2>(lhs)->gid() < std::get<2>(rhs)->gid()
-           );
-}
 
 // ==---------------------------------------------------------------
 // Factory methods for AST nodes

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -134,26 +134,33 @@ CodegenContext::CodegenContext()
        }, getComplexTy()
     });
 
-    /* TODO:
     BinOpCreator["DIV"].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()},
        [this] (std::vector<Value*> v){
-            auto cmplx1 = v[0];
-            auto cmplx2 = v[1];
-            auto c1re = this->Builder.CreateStructGEP(getComplexTy()->toLLVMs(), cmplx1, 0);
-            auto c1im = this->Builder.CreateStructGEP(getComplexTy()->toLLVMs(), cmplx1, 1);
-            auto c2re = this->Builder.CreateStructGEP(getComplexTy()->toLLVMs(), cmplx2, 0);
-            auto c2im = this->Builder.CreateStructGEP(getComplexTy()->toLLVMs(), cmplx2, 1);
+            auto c1re = this->Builder.CreateExtractValue(v[0], {0});
+            auto c1im = this->Builder.CreateExtractValue(v[0], {1});
+            auto c2re = this->Builder.CreateExtractValue(v[1], {0});
+            auto c2im = this->Builder.CreateExtractValue(v[1], {1});
             auto c1c2re = this->Builder.CreateFMul(c1re, c2re, "cmplxmultmp");
             auto c1c2im = this->Builder.CreateFMul(c1im, c2im, "cmplxmultmp");
             auto c1imc2re = this->Builder.CreateFMul(c1im, c2re, "cmplxmultmp");
             auto c1rec2im = this->Builder.CreateFMul(c1re, c2im, "cmplxmultmp");
-            auto reres = this->Builder.CreateFSub(c1c2re, c1c2im, "cmplxsubtmp");
-            auto imres = this->Builder.CreateFAdd(c1imc2re, c1rec2im, "cmplxaddtmp");
-            std::vector<llvm::Constant*> vek{dynamic_cast<llvm::Constant*>(reres), dynamic_cast<llvm::Constant*>(imres)};
-            return llvm::ConstantStruct::get(getComplexTy()->toLLVMs(), vek);
+            auto c2rere = this->Builder.CreateFMul(c2re, c2re, "cmplxmultmp");
+            auto c2imim = this->Builder.CreateFMul(c2im, c2im, "cmplxmultmp");
+            auto squares = this->Builder.CreateFAdd(c2rere, c2imim, "cmplxaddtmp");
+            auto left = this->Builder.CreateFAdd(c1c2re, c1c2im, "cmplxsubtmp");
+            auto right = this->Builder.CreateFSub(c1imc2re, c1rec2im, "cmplxaddtmp");
+            auto reres = this->Builder.CreateFDiv(left, squares, "cmplxdivtmp");
+            auto imres = this->Builder.CreateFDiv(right, squares, "cmplxdivtmp");
+            auto cmplx_t = getComplexTy()->toLLVMs();
+            AllocaInst* alloca = CreateEntryBlockAlloca(CurrentFunc, "cmplxtmp", cmplx_t);
+            auto idx1 = this->Builder.CreateStructGEP(cmplx_t, alloca, 0);
+            this->Builder.CreateStore(reres, idx1);
+            auto idx2 = this->Builder.CreateStructGEP(cmplx_t, alloca, 1);
+            this->Builder.CreateStore(imres, idx2);
+            auto retsload = this->Builder.CreateLoad(alloca, "Cmplxloadret");
+            return retsload;
        }, getComplexTy()
     });
-    */
 
     BinOpCreator["EQUAL"].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()},
        [this] (std::vector<Value*> v){

--- a/src/codegencontext.h
+++ b/src/codegencontext.h
@@ -100,6 +100,7 @@ public:
     std::shared_ptr<llvm::Module> TheModule;
     llvm::IRBuilder<> Builder;
     llvm::Function* CurrentFunc;
+    Type CurrentFuncReturnType;
     mutable std::map<std::string, std::pair<llvm::AllocaInst*, Type>> VarsInScope;
 
     std::map<std::string, std::list<MatchCandidateEntry>> BinOpCreator;

--- a/src/codegencontext.h
+++ b/src/codegencontext.h
@@ -16,8 +16,6 @@
 
 namespace ccoscope {
 
-void __cco_print_complex(ComplexValue c);
-
 class CodegenContext;
 
 /// CreateEntryBlockAlloca - Create an alloca instruction in the entry block of

--- a/src/codegencontext.h
+++ b/src/codegencontext.h
@@ -63,6 +63,7 @@ public:
     PrimitiveExpr<int> makeInt(int value);
     PrimitiveExpr<double> makeDouble(double value);
     PrimitiveExpr<bool> makeBool(bool value);
+    ComplexValue makeComplex(Expr re, Expr im);
     BinaryExpr makeBinary(std::string Op, Expr LHS, Expr RHS);
     ReturnExpr makeReturn(Expr expr);
     Block makeBlock(const std::vector<std::pair<std::string, Type>> &vars,
@@ -86,6 +87,7 @@ public:
     IntegerType getIntegerTy() const;
     DoubleType getDoubleTy() const;
     BooleanType getBooleanTy() const;
+    ComplexType getComplexTy() const;
     FunctionType getFunctionTy(Type ret, std::vector<Type> args) const;
     ReferenceType getReferenceTy(Type of) const;
 

--- a/src/codegencontext.h
+++ b/src/codegencontext.h
@@ -16,6 +16,8 @@
 
 namespace ccoscope {
 
+void __cco_print_complex(ComplexValue c);
+
 class CodegenContext;
 
 /// CreateEntryBlockAlloca - Create an alloca instruction in the entry block of

--- a/src/codegencontext.h
+++ b/src/codegencontext.h
@@ -50,14 +50,6 @@ struct GIDCmp {
     }
 };
 
-typedef std::function<llvm::Value*(llvm::Value*, llvm::Value*)> CreatorFunc;
-struct OperatorEntry{
-    Type t1;
-    Type t2;
-    CreatorFunc creator_function;
-    Type return_type;
-};
-
 class CodegenContext
 {
 public:
@@ -110,7 +102,7 @@ public:
     llvm::Function* CurrentFunc;
     mutable std::map<std::string, std::pair<llvm::AllocaInst*, Type>> VarsInScope;
 
-    std::map<std::string, std::list<OperatorEntry>> BinOpCreator;
+    std::map<std::string, std::list<MatchCandidateEntry>> BinOpCreator;
 
     // For tracking in which loop we are currently in
     // .first -- headerBB, .second -- postBB

--- a/src/codegencontext.h
+++ b/src/codegencontext.h
@@ -106,12 +106,12 @@ public:
     // ==---------------------------------------------------------------
     // Factory methods for Types
 
-    VoidType getVoidTy();
-    IntegerType getIntegerTy();
-    DoubleType getDoubleTy();
-    BooleanType getBooleanTy();
-    FunctionType getFunctionTy(Type ret, std::vector<Type> args);
-    ReferenceType getReferenceTy(Type of);
+    VoidType getVoidTy() const;
+    IntegerType getIntegerTy() const;
+    DoubleType getDoubleTy() const;
+    BooleanType getBooleanTy() const;
+    FunctionType getFunctionTy(Type ret, std::vector<Type> args) const;
+    ReferenceType getReferenceTy(Type of) const;
 
     // ==---------------------------------------------------------------
 
@@ -159,13 +159,13 @@ protected:
 
     // Is there a way to merge these two "introduces"? TODO: find a way!
     template<class T>
-    const T* introduceE(const T* node) { return introduce_expr(node)->template as<T>(); }
+    const T* introduceE(const T* node) const { return introduce_expr(node)->template as<T>(); }
     template<class T>
-    const T* introduceT(const T* node) { return introduce_type(node)->template as<T>(); }
-    const ExprAST* introduce_expr(const ExprAST*);
-    const TypeAST* introduce_type(const TypeAST*);
-    const PrototypeAST* introduce_prototype(const PrototypeAST*);
-    const FunctionAST* introduce_function(const FunctionAST*);
+    const T* introduceT(const T* node) const { return introduce_type(node)->template as<T>(); }
+    const ExprAST* introduce_expr(const ExprAST*) const;
+    const TypeAST* introduce_type(const TypeAST*) const;
+    const PrototypeAST* introduce_prototype(const PrototypeAST*) const;
+    const FunctionAST* introduce_function(const FunctionAST*) const;
 
     mutable size_t gid_;
 };

--- a/src/codegencontext.h
+++ b/src/codegencontext.h
@@ -50,22 +50,6 @@ struct GIDCmp {
     }
 };
 
-// naiive for now
-struct TypeHash { size_t operator () (const TypeAST* t) const { return 1; } };
-struct TypeEqual {
-    bool operator () (const TypeAST* t1, const TypeAST* t2) const {
-        return t1->equal(*t2);
-    }
-};
-
-using TypeSet = std::unordered_set<const TypeAST*, TypeHash, TypeEqual>;
-
-struct TTypeCmp {
-    bool operator () (const std::tuple<std::string, Type, Type>& lhs,
-                      const std::tuple<std::string, Type, Type>& rhs) const;
-};
-
-
 typedef std::function<llvm::Value*(llvm::Value*, llvm::Value*)> CreatorFunc;
 struct OperatorEntry{
     Type t1;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -78,7 +78,7 @@ int Compile(std::string infile, std::string outfile, unsigned int optlevel){
 
     auto ctx = CodegenContext{};
 
-    parser(tok, ctx, /*prototypes,definitions, */tkn_Start, 0);
+    parser(tok, ctx, tkn_Start, 0);
 
     // Instead of returning an exit status, the parser returns
     // nothing, and we need to determine if parsing was successful by

--- a/src/conversions.h
+++ b/src/conversions.h
@@ -1,7 +1,12 @@
 #ifndef __CONVERSIONS_H__
 #define __CONVERSIONS_H__
 
-#include "types.h"
+#include "proxy.h"
+
+#include "llvm/IR/Value.h"
+
+#include <functional>
+#include <map>
 
 namespace ccoscope{
 
@@ -11,8 +16,10 @@ class CodegenContext;
 typedef std::function<llvm::Value*(CodegenContext&, llvm::Value*)> ConverterFunction;
 typedef unsigned int ConversionCost;
 
+class TypeAST; using Type = Proxy<TypeAST>;
+
 struct Conversion{
-    Type orig_type;
+    //Type orig_type;
     Type target_type;
     ConversionCost cost;
     ConverterFunction converter;

--- a/src/conversions.h
+++ b/src/conversions.h
@@ -1,0 +1,23 @@
+#ifndef __CONVERSIONS_H__
+#define __CONVERSIONS_H__
+
+#include "types.h"
+
+namespace ccoscope{
+
+class OperatorEntry;
+class CodegenContext;
+
+typedef std::function<llvm::Value*(CodegenContext&, llvm::Value*)> ConverterFunction;
+typedef unsigned int ConversionCost;
+
+struct Conversion{
+    Type orig_type;
+    Type target_type;
+    ConversionCost cost;
+    ConverterFunction converter;
+};
+
+}
+
+#endif // __CONVERSIONS_H__

--- a/src/conversions.h
+++ b/src/conversions.h
@@ -10,7 +10,6 @@
 
 namespace ccoscope{
 
-class OperatorEntry;
 class CodegenContext;
 
 typedef std::function<llvm::Value*(CodegenContext&, llvm::Value*)> ConverterFunction;

--- a/src/lexer.lex
+++ b/src/lexer.lex
@@ -26,7 +26,7 @@ digit    [0-9]
 alpha    [a-zA-z]
 alphanum {digit}|{alpha}
 
-basetype int|bool|double
+basetype int|bool|double|complex
 
 /* Floats */
 exponent	[eE]-?{digit}+

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -16,11 +16,11 @@ template<class T>
 class Proxy {
 public:
     typedef T BaseType; // using BaseType = T; ?
-   
+
     Proxy()
         : node_(nullptr)
     {}
-    
+
     Proxy(const T* node)
         : node_(node)
     {
@@ -40,11 +40,11 @@ public:
     const T* operator -> () const { return *(*this); }
     //bool operator < (const Proxy<T>& other) const { return *(this->deref()) < *(other.deref()); }
     Proxy<T>& operator = (const Proxy<T>& other) { node_ = other.node(); return *this; }
-    
+
     bool is_empty() const { return node_ == nullptr; }
     //void dump(std::ostream& stream) const;
     //void dump() const { dump(std::cout); std::cout << std::endl; }
-    
+
     // casts
 
     operator bool() const { return node_; }
@@ -77,7 +77,7 @@ const T* Proxy<T>::deref() const {
     const T* target = node_;
     for (; target->is_proxy(); target = target->representative_->template as<T>())
         assert(target != nullptr);
-    
+
     return target->template as<T>();
 }
 

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -1,6 +1,9 @@
 #ifndef __PROXY_H__
 #define __PROXY_H__
 
+#include "cast.h"
+#include <assert.h>
+
 namespace ccoscope {
 
 //template<typename WORLD>

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -533,8 +533,8 @@ bool ComplexValueAST::Resolve() const {
             ctx().Builder.CreateStore(rev, idx1);
             auto idx2 = ctx().Builder.CreateStructGEP(ctx().getComplexTy()->toLLVMs(), rets, 1);
             ctx().Builder.CreateStore(imv, idx2);
-            
-            return rets;
+            auto retsload = ctx().Builder.CreateLoad(rets, "Cmplxloadret");
+            return retsload;
         },
         ctx().getComplexTy()
     };
@@ -697,18 +697,21 @@ bool CallExprAST::Resolve() const{
             },
             ctx().getVoidTy()
         };
-      /*  auto print_variant_boolean = MatchCandidateEntry{
+        auto print_variant_complex = MatchCandidateEntry{
             {ctx().getComplexTy()},
             [this](std::vector<llvm::Value*> v){
-                return ctx().Builder.CreateCall(ctx().GetStdFunction("print_bool"), v);
+                auto rev = ctx().Builder.CreateExtractValue(v[0], {0});
+                auto imv = ctx().Builder.CreateExtractValue(v[0], {1});
+                return ctx().Builder.CreateCall(ctx().GetStdFunction("print_complex"), {rev, imv});
             },
             ctx().getVoidTy()
-        };*/
+        };
 
         auto expr_type = Args[0]->maintype();
         auto match = ctx().typematcher.Match({print_variant_int,
                                               print_variant_double,
-                                              print_variant_boolean},
+                                              print_variant_boolean,
+                                              print_variant_complex},
                                              {expr_type}
             );
 

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -73,8 +73,8 @@ llvm::Value* BinaryExprAST::codegen() const {
     if(!valL || !valR) return nullptr;
 
     auto match = ctx().typematcher.MatchOperator(Opcode, LHS->maintype(), RHS->maintype());
-    if(!match) return nullptr; // The matcher already reported an error.
-    return match->creator_function(valL, valR);
+    if(!match.found) return nullptr; // The matcher already reported an error.
+    return match.application_function(ctx(), {valL, valR});
 }
 
 llvm::Value* ReturnExprAST::codegen() const {
@@ -493,8 +493,8 @@ Type VariableExprAST::maintype() const {
 
 Type BinaryExprAST::maintype() const {
     auto match = ctx().typematcher.MatchOperator(Opcode, LHS->maintype(), RHS->maintype());
-    if(!match) return ctx().getVoidTy();
-    return match->return_type;
+    if(!match.found) return ctx().getVoidTy();
+    return match.return_type;
 }
 
 Type AssignmentAST::maintype() const {

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -178,6 +178,7 @@ llvm::Value* CallExprAST::codegen() const {
         std::cerr << "in call will codegen arg" << std::endl;
 #endif
         auto temp = Args[0]->codegen();
+        if(!temp) return nullptr;
        // auto vare = dynamic_cast<VariableExprAST*>(Args[0]);
       //  if(vare != nullptr) {
       //      std::cerr << "codegening var
@@ -493,6 +494,7 @@ Type VariableExprAST::maintype() const {
 
 Type BinaryExprAST::maintype() const {
     auto match = ctx().typematcher.MatchOperator(Opcode, LHS->maintype(), RHS->maintype());
+    // TODO: If no match found, stop codegenning.
     if(!match.found) return ctx().getVoidTy();
     return match.return_type;
 }

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -530,9 +530,11 @@ BlockAST::ScopeManager::~ScopeManager() {
 
 bool ComplexValueAST::Resolve() const {
     Type Retype = Re->maintype();
+    std::cerr << "retype is " << Retype->name() << std::endl;
     Type Imtype = Im->maintype();
+    auto dblt = ctx().getDoubleTy();
     auto ret = MatchCandidateEntry{
-        {Retype, Imtype},
+        {dblt, dblt},
         [this](std::vector<llvm::Value*> v){
             auto rev = v[0];
             auto imv = v[1];

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -235,10 +235,21 @@ llvm::Value* CallExprAST::codegen() const {
             },
             ctx().getVoidTy()
         };
+        auto print_variant_boolean = MatchCandidateEntry{
+            {ctx().getBooleanTy()},
+            [this](std::vector<llvm::Value*> v){
+                return ctx().Builder.CreateCall(ctx().func_printf, std::vector<llvm::Value*>{
+                        CreateI8String("%d\n", ctx()),
+                        v[0]
+                }, "calltmp");
+            },
+            ctx().getVoidTy()
+        };
 
         auto expr_type = Args[0]->maintype();
         auto match = ctx().typematcher.Match({print_variant_int,
-                                              print_variant_double},
+                                              print_variant_double,
+                                              print_variant_boolean},
                                              {expr_type}
             );
 

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -542,19 +542,39 @@ bool ComplexValueAST::Resolve() const {
          //   auto imv = Im->codegen();
          std::cerr << "in complex constructor, re value is " << std::endl;
          rev->dump();
-         std::cerr << " and im value is " << std::endl;
-         imv->dump();
-         std::cerr << " after cast to constant re is " << std::endl;
-            auto rec = dynamic_cast<llvm::Constant*>(rev);
-        if(rec)
-            rec->dump();
-        else
-            std::cerr << "nullptr!";
+         std::cerr << " and its type is " << std::endl;
+         imv->getType()->dump();
+      //   std::cerr << " after cast to constant re is " << std::endl;
+       //     auto rec = llvm::cast<llvm::Constant>(rev);//dynamic_cast<llvm::Constant*>(rev);
+       // if(rec)
+       //     rec->dump();
+       // else
+       //     std::cerr << "nullptr!";
         std::cerr << std::endl;
-            auto imc = dynamic_cast<llvm::Constant*>(imv);
-            std::vector<llvm::Constant*> vek{rec, imc};
-            return llvm::ConstantStruct::get(maintype().as<ComplexType>()->toLLVMs(), vek);
-
+       //     auto imc = llvm::cast<llvm::Constant>(imv);//dynamic_cast<llvm::Constant*>(imv);
+         //   std::vector<llvm::Constant*> vek{rec, imc};
+            //auto rets = ctx().getComplexTy()->defaultLLVMsValue();
+            auto rets = ctx().VarsInScope["Cmplx"].first;
+            std::cerr << "made struct: ";
+            rets->dump();
+            auto idx1 = ctx().Builder.CreateStructGEP(ctx().getComplexTy()->toLLVMs(), rets, 0);
+            if(idx1) {
+                std::cerr << "\nand got its first index as\n";
+                idx1->dump();
+            }
+            else 
+                std::cerr << "idx1 is nullptr!" << std::endl;
+            auto stor = ctx().Builder.CreateStore(rev, idx1);
+            std::cerr << "\nand created store \n";
+            stor->dump();
+            std::cerr << "\nnow sturct looks like: ";
+            rets->dump();
+            std::cerr << std::endl;
+            
+            auto idx2 = ctx().Builder.CreateStructGEP(ctx().getComplexTy()->toLLVMs(), rets, 1);
+            ctx().Builder.CreateStore(imv, idx2);
+            
+            return rets;
             //return val;
 
         },

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -538,9 +538,9 @@ bool ComplexValueAST::Resolve() const {
         },
         ctx().getComplexTy()
     };
-    
+
     auto match = ctx().typematcher.Match({ret}, {Retype, Imtype});
-    
+
     if(match.type == TypeMatcher::Result::NONE) {
         ctx().AddError("No matching complex constructor found to call with types: " +
                      Retype->name() + ", " + Imtype->name() + ".");

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -385,7 +385,7 @@ std::vector<Type> PrototypeAST::GetSignature() const{
     return result;
 }
 
-llvm::Function *FunctionAST::codegen() const {
+llvm::Function* FunctionAST::codegen() const {
     using namespace llvm;
 
     // First, check for an existing function from a previous 'extern' declaration.
@@ -443,12 +443,7 @@ llvm::Function *FunctionAST::codegen() const {
 Type ExprAST::maintype() const {
     return ctx().getVoidTy();
 }
-/* see `tree.h`
-template<typename T>
-ExprType PrimitiveExprAST<T>::maintype(CodegenContext& ctx) const {
-    return {std::make_shared<PrimitiveExprAST<int>>(42), CCVoidType()};
-}
-*/
+
 template<>
 Type PrimitiveExprAST<int>::maintype() const {
     return ctx().getIntegerTy();

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -85,11 +85,11 @@ llvm::Value* BinaryExprAST::codegen() const {
 
     if(match.type == TypeMatcher::Result::NONE) {
         ctx().AddError("No matching operator '" + opcode + "' found to call with types: " +
-                     Ltype.deref()->name() + ", " + Rtype.deref()->name() + ".");
+                     Ltype->name() + ", " + Rtype->name() + ".");
         return nullptr;
     }else if(match.type == TypeMatcher::Result::MULTIPLE){
         ctx().AddError("Multiple candidates for operator '" + opcode + "' and types: " +
-                     Ltype.deref()->name() + ", " + Rtype.deref()->name() + ".");
+                     Ltype->name() + ", " + Rtype->name() + ".");
         return nullptr;
     }else{
         // First, perform the conversion.
@@ -187,11 +187,11 @@ llvm::Value* AssignmentAST::codegen() const {
 
     if(match.type == TypeMatcher::Result::NONE){
         ctx().AddError("Assignment failed, type mismatch: Cannot implicitly convert a " +
-                       expr_type.deref()->name() + " to " + target_type.deref()->name());
+                       expr_type->name() + " to " + target_type->name());
         return nullptr;
     }else if(match.type == TypeMatcher::Result::MULTIPLE){
         ctx().AddError("Assignment failed, type mismatch: Multiple equally viable implicit conversions from " +
-                       expr_type.deref()->name() + " to " + target_type.deref()->name() + " are available");
+                       expr_type->name() + " to " + target_type->name() + " are available");
         return nullptr;
     }else{
 
@@ -222,7 +222,7 @@ llvm::Value* CallExprAST::codegen() const {
         else if(mt == ctx().getIntegerTy())
             formatSpecifier = "%d";
         else{
-            ctx().AddError("Unable to print a variable of type " + mt.deref()->name());
+            ctx().AddError("Unable to print a variable of type " + mt->name());
             return nullptr;
         }
 
@@ -560,11 +560,11 @@ Type BinaryExprAST::maintype() const {
 
     if(match.type == TypeMatcher::Result::NONE) {
         ctx().AddError("No matching operator '" + opcode + "' found to call with types: " +
-                     Ltype.deref()->name() + ", " + Rtype.deref()->name() + ".");
+                     Ltype->name() + ", " + Rtype->name() + ".");
         return ctx().getVoidTy();
     }else if(match.type == TypeMatcher::Result::MULTIPLE){
         ctx().AddError("Multiple candidates for operator '" + opcode + "' and types: " +
-                     Ltype.deref()->name() + ", " + Rtype.deref()->name() + ".");
+                     Ltype->name() + ", " + Rtype->name() + ".");
         return ctx().getVoidTy();
     }else
         return match.match.return_type;

--- a/src/tree.h
+++ b/src/tree.h
@@ -46,17 +46,17 @@ public:
         , gid_(gid)
         , representative_(this)
     {}
-    
+
     virtual ~ExprAST() {}
-    
+
     virtual llvm::Value* codegen() const = 0;
     virtual Type maintype() const;
-    
+
     size_t gid () const { return gid_; }
     CodegenContext& ctx () const { return ctx_; }
     bool equal(const ExprAST& other) const;
     bool is_proxy () const { return representative_ != this; }
-    
+
 protected:
     CodegenContext& ctx_;
     size_t gid_;
@@ -70,11 +70,11 @@ protected:
 template<typename T>
 class PrimitiveExprAST : public ExprAST {
 public:
-    PrimitiveExprAST(CodegenContext& ctx, size_t gid, T v) 
-        : ExprAST(ctx, gid) 
+    PrimitiveExprAST(CodegenContext& ctx, size_t gid, T v)
+        : ExprAST(ctx, gid)
         , Val(v)
     {}
-    
+
     llvm::Value* codegen() const override;
     virtual Type maintype () const override;
 
@@ -97,10 +97,10 @@ public:
         : ExprAST(ctx, gid)
         , Name(Name)
     {}
-    
+
     llvm::Value* codegen() const override;
     virtual Type maintype () const override;
-    
+
 protected:
     std::string Name;
 };
@@ -110,14 +110,14 @@ class BinaryExprAST : public ExprAST {
 public:
     BinaryExprAST(CodegenContext& ctx, size_t gid, std::string Op, Expr LHS, Expr RHS)
         : ExprAST(ctx, gid)
-        , Opcode(Op), LHS(LHS), RHS(RHS), bestOverload(nullptr)
+        , opcode(Op), LHS(LHS), RHS(RHS), bestOverload(nullptr)
     {}
-    
+
     llvm::Value* codegen() const override;
     virtual Type maintype () const override;
-    
+
 protected:
-    std::string Opcode;
+    std::string opcode;
     Expr LHS, RHS;
     llvm::Function* bestOverload;
 };
@@ -129,7 +129,7 @@ public:
         : ExprAST(ctx, gid)
         , Expression(expr)
     {}
-    
+
     llvm::Value* codegen() const override;
 
 protected:
@@ -147,26 +147,26 @@ protected:
             , ctx(ctx)
         {}
         ~ScopeManager();
-        
+
     protected:
         const BlockAST* parent;
         CodegenContext& ctx;
     };
 
 public:
-    BlockAST(CodegenContext& ctx, size_t gid, 
-             const std::vector<std::pair<std::string, Type>> &vars, 
+    BlockAST(CodegenContext& ctx, size_t gid,
+             const std::vector<std::pair<std::string, Type>> &vars,
              const std::list<Expr>& s)
         : ExprAST(ctx, gid)
         , Vars(vars), Statements(s)
     {}
-    
+
     llvm::Value* codegen() const override;
-    
+
 protected:
     std::vector<std::pair<std::string, Type>> Vars;
     std::list<Expr> Statements;
-    
+
     friend ForExprAST;
 };
 
@@ -178,7 +178,7 @@ public:
         : ExprAST(ctx, gid)
         , Name(Name), Expression(expr)
     {}
-    
+
     llvm::Value* codegen() const override;
     virtual Type maintype () const override;
 
@@ -195,7 +195,7 @@ public:
         : ExprAST(ctx, gid)
         , Callee(Callee), Args(std::move(Args))
     {}
-    
+
     llvm::Value* codegen() const override;
     virtual Type maintype () const override;
 
@@ -211,7 +211,7 @@ public:
         : ExprAST(ctx, gid)
         , Cond(Cond), Then(Then), Else(Else)
     {}
-    
+
     llvm::Value* codegen() const override;
 
 protected:
@@ -225,7 +225,7 @@ public:
         : ExprAST(ctx, gid)
         , Cond(Cond), Body(Body)
     {}
-    
+
     llvm::Value* codegen() const override;
 
 protected:
@@ -241,7 +241,7 @@ public:
         , Init(Init), Cond(Cond),
           Step(Step), Body(Body)
     {}
-    
+
     llvm::Value* codegen() const override;
 
 protected:
@@ -256,7 +256,7 @@ public:
         : ExprAST(ctx, gid)
         , which(which)
     {}
-    
+
     llvm::Value* codegen() const override;
 
 protected:
@@ -270,12 +270,12 @@ protected:
 /// of arguments the function takes).
 class PrototypeAST : public ExprAST {
 public:
-    PrototypeAST(CodegenContext& ctx, size_t gid, const std::string &Name, 
+    PrototypeAST(CodegenContext& ctx, size_t gid, const std::string &Name,
                  std::vector<std::pair<std::string, Type>> Args, Type ReturnType)
         : ExprAST(ctx, gid)
         , Name(Name), Args(std::move(Args)), ReturnType(ReturnType)
     {}
-    
+
     const std::string &getName() const { return Name; }
     Type getReturnType() const { return ReturnType; }
     const std::vector<std::pair<std::string, Type>>& getArgs() const { return Args; }
@@ -286,7 +286,7 @@ protected:
     std::string Name;
     std::vector<std::pair<std::string, Type>> Args;
     Type ReturnType;
-    
+
     friend class FunctionAST;
 };
 
@@ -297,7 +297,7 @@ public:
         : ExprAST(ctx, gid)
         , Proto(Proto), Body(Body)
     {}
-    
+
     llvm::Function* codegen() const override;
     Type maintype () const override;
 

--- a/src/tree.h
+++ b/src/tree.h
@@ -105,7 +105,7 @@ Type PrimitiveExprAST<T>::maintype() const {
     return ctx.getVoidTy();
 }*/
 
-class ComplexValueAST : public ExprAST {
+class ComplexValueAST : public ExprAST, protected Resolvable {
 public:
     ComplexValueAST(CodegenContext& ctx, size_t gid, Expr re, Expr im)
         : ExprAST(ctx, gid)
@@ -118,6 +118,8 @@ public:
 
 protected:
     Expr Re, Im;
+    
+    bool Resolve() const override;
 };
 
 /// VariableExprAST - Expression class for referencing a variable, like "a".

--- a/src/tree.h
+++ b/src/tree.h
@@ -115,7 +115,7 @@ public:
 
     llvm::Value* codegen() const override;
     virtual Type maintype () const override;
-
+    
 protected:
     Expr Re, Im;
     

--- a/src/tree.h
+++ b/src/tree.h
@@ -115,10 +115,10 @@ public:
 
     llvm::Value* codegen() const override;
     virtual Type maintype () const override;
-    
+
 protected:
     Expr Re, Im;
-    
+
     bool Resolve() const override;
 };
 

--- a/src/tree.h
+++ b/src/tree.h
@@ -282,6 +282,9 @@ public:
     llvm::Function* codegen() const override;
     Type maintype () const override;
 
+    std::vector<Type> GetSignature() const;
+    Type GetReturnType() const {return ReturnType;}
+
 protected:
     std::string Name;
     std::vector<std::pair<std::string, Type>> Args;

--- a/src/tree.h
+++ b/src/tree.h
@@ -26,6 +26,7 @@ enum class keyword {
 class ExprAST;             using Expr                = Proxy<ExprAST>;
 template<typename T> class PrimitiveExprAST;
 template<typename T> using PrimitiveExpr = Proxy<PrimitiveExprAST<T>>;
+class ComplexValueAST;     using ComplexValue        = Proxy<ComplexValueAST>;
 class VariableExprAST;     using VariableExpr        = Proxy<VariableExprAST>;
 class BinaryExprAST;       using BinaryExpr          = Proxy<BinaryExprAST>;
 class ReturnExprAST;       using ReturnExpr          = Proxy<ReturnExprAST>;
@@ -103,6 +104,21 @@ template<typename T>
 Type PrimitiveExprAST<T>::maintype() const {
     return ctx.getVoidTy();
 }*/
+
+class ComplexValueAST : public ExprAST {
+public:
+    ComplexValueAST(CodegenContext& ctx, size_t gid, Expr re, Expr im)
+        : ExprAST(ctx, gid)
+        , Re(re)
+        , Im(im)
+    {}
+
+    llvm::Value* codegen() const override;
+    virtual Type maintype () const override;
+
+protected:
+    Expr Re, Im;
+};
 
 /// VariableExprAST - Expression class for referencing a variable, like "a".
 class VariableExprAST : public ExprAST {

--- a/src/typematcher.cpp
+++ b/src/typematcher.cpp
@@ -1,0 +1,29 @@
+#include "typematcher.h"
+#include "codegencontext.h"
+
+namespace ccoscope{
+
+const OperatorEntry* TypeMatcher::MatchOperator(std::string name, Type t1, Type t2){
+    // TODO: implicit conversions and stuff
+
+    // Currently the matcher does a first fit search, and it ignores possible implicit conversions.
+
+    auto fitit = ctx.BinOpCreator.find(name);
+
+    if(fitit == ctx.BinOpCreator.end()) {
+        ctx.AddError("Operator's '" + name + "' codegen is not implemented!");
+        return nullptr;
+    }
+    else{
+        for(const OperatorEntry& oe : fitit->second){
+            // First-fit
+            if(oe.t1 == t1 && oe.t2 == t2)
+                return &oe;
+        }
+        // TODO: Printout type names
+        ctx.AddError("No match found for operator '" + name + "' and these types.");
+        return nullptr;
+    }
+}
+
+}

--- a/src/typematcher.cpp
+++ b/src/typematcher.cpp
@@ -71,8 +71,7 @@ const TypeMatcher::Result TypeMatcher::MatchOperator(std::string name, Type t1, 
     );
     // If no combinations remain, fail.
     if(combinations.size() == 0){
-        //TODO: Print type names
-        ctx.AddError("No matching operator '" + name + "' found to call with these types.");
+        ctx.AddError("No matching operator '" + name + "' found to call with types: " + t1.deref()->name() + ", " + t2.deref()->name() + ".");
         return Result();
     }
     // Summarize conversion costs for each combination
@@ -95,7 +94,7 @@ const TypeMatcher::Result TypeMatcher::MatchOperator(std::string name, Type t1, 
     }else if(combinations_with_total_costs.size() > 1){
         //TODO: Print type names
         //TODO: Use combinations_with_total_costs to inform the user about possible candidates
-        ctx.AddError("Multiple candidates for operator '" + name + "' and these types.");
+        ctx.AddError("Multiple candidates for operator '" + name + "' and types: " + t1.deref()->name() + ", " + t2.deref()->name() + ".");
         return Result();
     }
     // We have confirmed that there is indeed just one match. Let's unwrap it:

--- a/src/typematcher.cpp
+++ b/src/typematcher.cpp
@@ -1,29 +1,172 @@
 #include "typematcher.h"
 #include "codegencontext.h"
+#include <algorithm>
 
 namespace ccoscope{
 
-const OperatorEntry* TypeMatcher::MatchOperator(std::string name, Type t1, Type t2){
-    // TODO: implicit conversions and stuff
+void TypeMatcher::InitImplicitConversions(){
+    implicit_conversions[ctx.getIntegerTy()] = { // Conversions from int
+        Conversion{
+            ctx.getIntegerTy(),
+            ctx.getDoubleTy(),                   // --- to double
+            1,                                   // ----- costs 1
+            [](CodegenContext & ctx, llvm::Value* v)->llvm::Value*{  // Note: The CodegenContext is passed again. We
+                                                                     // canot reuse the parent context, because we
+                                                                     // need a non-const context.
+                return ctx.Builder.CreateSIToFP(v, llvm::Type::getDoubleTy(llvm::getGlobalContext()), "convtmp");
+            }
+        }
+    };
 
+    //TODO: Is there any other conversion we should use? I really
+    // dislike implicit conversions from/to boolean types, and
+    // implicit conversion double->int seems ugly. So until we have
+    // more types, this is probably the only implicit conversion we
+    // use...
+}
+
+// Helper function for calcluating a sum of conversion costs
+static ConversionCost Summarize(const std::vector<Conversion>& v){
+    ConversionCost sum = 0;
+    for(const Conversion& c : v) sum += c.cost;
+    return sum;
+}
+
+const TypeMatcher::Result TypeMatcher::MatchOperator(std::string name, Type t1, Type t2) const{
     // Currently the matcher does a first fit search, and it ignores possible implicit conversions.
 
-    auto fitit = ctx.BinOpCreator.find(name);
-
-    if(fitit == ctx.BinOpCreator.end()) {
+    // Get the list of operator variants under this name
+    auto opit = ctx.BinOpCreator.find(name);
+    if(opit == ctx.BinOpCreator.end()) {
         ctx.AddError("Operator's '" + name + "' codegen is not implemented!");
-        return nullptr;
+        return Result();
     }
-    else{
-        for(const OperatorEntry& oe : fitit->second){
-            // First-fit
-            if(oe.t1 == t1 && oe.t2 == t2)
-                return &oe;
+    const std::list<OperatorEntry>& operator_variants = opit->second;
+
+    // Prepare type signature
+    std::vector<Type> signature = {t1, t2};
+    // Generate possible conversions for each input type
+    std::vector<std::list<Conversion>> inflated = InflateTypes(signature);
+    // Generate all combinations of conversions
+    std::list<std::vector<Conversion>> combinations = CombinationWalker(inflated);
+    // Filter out those that match some operator
+    combinations.remove_if(
+        [&](const std::vector<Conversion> v){
+            Type target_1 = v[0].target_type;
+            Type target_2 = v[1].target_type;
+            // Search for a matching OperatorEntry. This is not O(1)! It could
+            // be if operator_variants was a map instead of a list... but then
+            // the BinOpCreator would be a
+            //   map(string -> map( (type,type) -> (type,function) )
+            // and that seems just mad. We might use that approach once there is A LOT of possible conversions.
+            for(const OperatorEntry& oe : operator_variants){
+                if(oe.t1 == target_1 && oe.t2 == target_2){
+                    // Match! Do not remove this conversion combination
+                    return false;
+                }
+            }
+            // No match found. Remove this combination.
+            return true;
         }
-        // TODO: Printout type names
-        ctx.AddError("No match found for operator '" + name + "' and these types.");
-        return nullptr;
+    );
+    // If no combinations remain, fail.
+    if(combinations.size() == 0){
+        //TODO: Print type names
+        ctx.AddError("No matching operator '" + name + "' found to call with these types.");
+        return Result();
     }
+    // Summarize conversion costs for each combination
+    std::list<std::pair<ConversionCost, std::vector<Conversion>>> combinations_with_total_costs;
+    for(const std::vector<Conversion> v : combinations)
+        combinations_with_total_costs.push_back({ Summarize(v), v});
+    // Find the minimal cost
+    ConversionCost minimum = combinations_with_total_costs.front().first;
+    for(const auto& p : combinations_with_total_costs)
+        if(p.first < minimum)
+            minimum = p.first;
+    // Filter out combinations that have non-optimal cost
+    combinations_with_total_costs.remove_if([&](auto p){
+            return p.first != minimum;
+        });
+    // At this point, exactly one match should be left.
+    if(combinations_with_total_costs.size() == 0){
+        ctx.AddError("Internal error: the above operations should not have emptied the combination list.");
+        return Result();
+    }else if(combinations_with_total_costs.size() > 1){
+        //TODO: Print type names
+        //TODO: Use combinations_with_total_costs to inform the user about possible candidates
+        ctx.AddError("Multiple candidates for operator '" + name + "' and these types.");
+        return Result();
+    }
+    // We have confirmed that there is indeed just one match. Let's unwrap it:
+    std::vector<Conversion> best_match = combinations_with_total_costs.front().second;
+    // Now find the operator variant for this match.
+    for(const OperatorEntry& oe : operator_variants){
+        if(oe.t1 != best_match[0].target_type || oe.t2 != best_match[1].target_type) continue;
+#if DEBUG
+        std::cout << "Operator '" + name  + "' variant used: " << oe.t1.deref()->name() << " " << oe.t2.deref()->name() << std::endl;
+        std::cout << "Conversion 1 is from " << best_match[0].orig_type.deref()->name()
+                  << " to " << best_match[0].target_type.deref()->name() << std::endl;
+        std::cout << "Conversion 2 is from " << best_match[1].orig_type.deref()->name()
+                  << " to " << best_match[1].target_type.deref()->name() << std::endl;
+#endif
+
+        // At this point, oe is the matching operator variant.
+        // Finally, we can prepare the application function.
+        ConverterFunction cf1 = best_match[0].converter;
+        ConverterFunction cf2 = best_match[1].converter;
+        CreatorFunc op_function = oe.creator_function;
+        Result::ApplicationFunction af = [cf1, cf2,op_function](CodegenContext& ctx, std::vector<llvm::Value*> v) -> llvm::Value*{
+            // Note: This function assumes that v.size() == 2. This is always
+            // the case for binary operators, but it could be generalized for
+            // different operators and overladed functions so that it would
+            // support any-sized vector.
+            // Conversions...
+            llvm::Value* c1 = cf1(ctx, v[0]);
+            llvm::Value* c2 = cf2(ctx, v[1]);
+            // Operator...
+            return op_function(c1, c2);
+        };
+        return Result(true, oe.return_type, af);
+    }
+    // assert(false)
+    ctx.AddError("Internal error: Match was found, but it has no corresponding operator variant.");
+    return Result();
+}
+
+std::list<Conversion> TypeMatcher::Inflate(Type t) const{
+    // TODO: Support transitive implicit conversions!  It does not matter now,
+    // as we only have a int->double conversion, but at somepoint we may want to
+    // use multi-step conversions, like int->float->double. I believe the
+    // support can be implemented by modifying only this function - this will
+    // require walking a Dijkstra on the conversion graph, summing the costs on
+    // our way, and joining the conversion functions. Should be pretty
+    // straight-forward, but as we currently have no tools to test this, I'll
+    // stay with this simple implementation that does not consider transitive
+    // conversions.
+
+    // std::cout << "Inflating a " << t.deref()->name() << std::endl;
+
+    std::list<Conversion> result;
+    // Identity conversion
+    Conversion id{t,t,0,
+            [](CodegenContext&, llvm::Value* v){return v;}
+    };
+    result.push_back(id);
+
+    // Look up possible conversions from requested type
+    auto it = implicit_conversions.find(t);
+    if(it != implicit_conversions.end()){
+        result.insert(result.end(), it->second.begin(), it->second.end());
+    }
+
+    return result;
+}
+
+std::vector<std::list<Conversion>> TypeMatcher::InflateTypes(std::vector<Type> v) const{
+    std::vector<std::list<Conversion>> result(v.size());
+    std::transform(v.begin(), v.end(), result.begin(), [&](Type t){return Inflate(t);});
+    return result;
 }
 
 }

--- a/src/typematcher.cpp
+++ b/src/typematcher.cpp
@@ -113,9 +113,9 @@ std::list<Conversion> TypeMatcher::ListTransitiveConversions(Type t) const{
     // stay with this simple implementation that does not consider transitive
     // conversions.
 
-    // std::cout << "Inflating a " << t.deref()->name() << std::endl;
+    // std::cout << "Inflating a " << t->name() << std::endl;
 
-    std::list<Conversion> result = t.deref()->ListConversions();
+    std::list<Conversion> result = t->ListConversions();
 
     // Identity conversion
     Conversion id{t,0,

--- a/src/typematcher.h
+++ b/src/typematcher.h
@@ -3,17 +3,16 @@
 #define __TYPEMATCHER_H__
 
 #include "conversions.h"
+#include "types.h"
 #include <string>
 #include <list>
+#include <vector>
 
 namespace ccoscope{
 
 class TypeMatcher{
 public:
     TypeMatcher(const CodegenContext& c) : ctx(c) {}
-
-    void InitImplicitConversions();
-
 
     struct Result{
         bool found; // false if no match was found at all
@@ -41,11 +40,6 @@ private:
     // Reference to parent, used to get types.
     const CodegenContext& ctx;
 
-    // Storage for implicit conversions lists (graph?)
-    std::map<Type, std::list<Conversion>, TypeCmp> implicit_conversions;
-
-    // For a given type, returns a list of possible conversions
-    std::list<Conversion> ListConversions(Type) const;
     // For a given type, returns a list of possible conversions, including an
     // identity conversion and an transitive conversions
     std::list<Conversion> ListTransitiveConversions(Type) const;

--- a/src/typematcher.h
+++ b/src/typematcher.h
@@ -2,25 +2,11 @@
 #ifndef __TYPEMATCHER_H__
 #define __TYPEMATCHER_H__
 
-#include "types.h"
+#include "conversions.h"
 #include <string>
 #include <list>
 
 namespace ccoscope{
-
-class OperatorEntry;
-class CodegenContext;
-
-typedef std::function<llvm::Value*(CodegenContext&, llvm::Value*)> ConverterFunction;
-typedef unsigned int ConversionCost;
-
-struct Conversion{
-    Type orig_type;
-    Type target_type;
-    ConversionCost cost;
-    ConverterFunction converter;
-};
-
 
 class TypeMatcher{
 public:
@@ -58,9 +44,11 @@ private:
     // Storage for implicit conversions lists (graph?)
     std::map<Type, std::list<Conversion>, TypeCmp> implicit_conversions;
 
-    // For a given type, returns a list of possible conversions (including an
-    // identity conversion)
-    std::list<Conversion> Inflate(Type) const;
+    // For a given type, returns a list of possible conversions
+    std::list<Conversion> ListConversions(Type) const;
+    // For a given type, returns a list of possible conversions, including an
+    // identity conversion and an transitive conversions
+    std::list<Conversion> ListTransitiveConversions(Type) const;
     // Replaces each type on the list with all possible conversions
     std::vector<std::list<Conversion>> InflateTypes(std::vector<Type>) const;
 };

--- a/src/typematcher.h
+++ b/src/typematcher.h
@@ -31,9 +31,8 @@ public:
         // This function performs matched conversion
         typedef std::function<std::vector<llvm::Value*>(CodegenContext&, std::vector<llvm::Value*> input)> BatchConverterFunction;
         BatchConverterFunction converter_function;
-    private:
-        friend class TypeMatcher; // Only a TypeMatcher can construct results
-        Result(ResultType t) : type(t) {}
+
+        Result(ResultType t = NONE) : type(t) {}
         Result(const ResultType& r, const MatchCandidateEntry& e, BatchConverterFunction func) :
             type(r), match(e), converter_function(func) {}
     };

--- a/src/typematcher.h
+++ b/src/typematcher.h
@@ -2,27 +2,110 @@
 #ifndef __TYPEMATCHER_H__
 #define __TYPEMATCHER_H__
 
-#include <string>
 #include "types.h"
+#include <string>
+#include <list>
 
 namespace ccoscope{
 
 class OperatorEntry;
 class CodegenContext;
 
+typedef std::function<llvm::Value*(CodegenContext&, llvm::Value*)> ConverterFunction;
+typedef unsigned int ConversionCost;
+
+struct Conversion{
+    Type orig_type;
+    Type target_type;
+    ConversionCost cost;
+    ConverterFunction converter;
+};
+
+
 class TypeMatcher{
 public:
     TypeMatcher(const CodegenContext& c) : ctx(c) {}
 
-    // Returns nullptr if no match or multiple matches, and writes corresponding
-    // errors to the parent context.
-    const OperatorEntry* MatchOperator(std::string name, Type t1, Type t2);
+    void InitImplicitConversions();
 
-    // TODO: Implement function overloading
-    // const FunctionEntry* MatchFunction(std::string name, std::list<Type> argtypes)
+
+    struct Result{
+        bool found; // false if no match was found at all
+        Type return_type;
+        // This function performs matched conversion AND applies the corresponding operator.
+        typedef std::function<llvm::Value*(CodegenContext&, std::vector<llvm::Value*>)> ApplicationFunction;
+        ApplicationFunction application_function;
+    private:
+        friend class TypeMatcher; // Only a TypeMatcher can construct results
+        Result() : found(false) {}
+        Result(const bool& f, const Type& r, ApplicationFunction af) :
+            found(f), return_type(r), application_function(af) {}
+    };
+
+    // Returns a TypemMatcher::Result, and writes corresponding errors to the
+    // parent context.
+    const Result MatchOperator(std::string name, Type t1, Type t2) const;
+
+    // TODO: Implement function overloading, very similar to operator
+    // resolution, but needs some kind of name-mangling first
+    // const Result MatchFunction(std::string name, std::vector<Type> argtypes) const;
+
+
 private:
+    // Reference to parent, used to get types.
     const CodegenContext& ctx;
+
+    // Storage for implicit conversions lists (graph?)
+    std::map<Type, std::list<Conversion>, TypeCmp> implicit_conversions;
+
+    // For a given type, returns a list of possible conversions (including an
+    // identity conversion)
+    std::list<Conversion> Inflate(Type) const;
+    // Replaces each type on the list with all possible conversions
+    std::vector<std::list<Conversion>> InflateTypes(std::vector<Type>) const;
 };
+}
+
+// Generates a list of possible combinations, each one is a vector whose nth
+//  element is picked from nth list.  See input/output types, this is the only
+//  reasonable pure function on these types.  On one hand, this is very
+//  straight-forward combination generator. On the other, this is one of the
+//  most wicked templates I've ever written. Note: This would be a one-liner in
+//  any functional language.
+template <typename T>
+std::list<std::vector<T>> CombinationWalker(const std::vector<std::list<T>>& in){
+    typedef typename std::list<T>::const_iterator list_it;
+    std::list<std::vector<T>> result;
+    unsigned int combination_size = in.size();
+    std::vector<list_it> iterators(combination_size);
+    // Initialize iterators with begins
+    std::transform(in.begin(), in.end(), iterators.begin(), [](const std::list<T>& l){return l.begin();});
+    // Generate combinations
+    while(true){
+        // Multidimentional dereference
+        std::vector<T> current_combination(combination_size);
+        std::transform(iterators.begin(), iterators.end(), current_combination.begin(), [](list_it it){return *it;});
+        //std::cout << "Inserting a combination" << std::endl;
+        result.push_back(current_combination);
+
+        // Increment combination.
+        for(unsigned int i = 0; i <= combination_size; i++){
+            if(i == combination_size){
+                // If incrementing the last iterator has overflown, it means we've found all possible combinations.
+                return result;
+            }
+            iterators[i]++;
+            if(iterators[i] == in[i].end()){
+                // Carry
+                iterators[i] = in[i].begin();
+                continue;
+            }else{
+                // Done.
+                break;
+            }
+
+        }
+    }
 }
 
 #endif // __TYPEMATCHER_H__

--- a/src/typematcher.h
+++ b/src/typematcher.h
@@ -1,0 +1,28 @@
+// -*- mode: c++; fill-column: 80 -*-
+#ifndef __TYPEMATCHER_H__
+#define __TYPEMATCHER_H__
+
+#include <string>
+#include "types.h"
+
+namespace ccoscope{
+
+class OperatorEntry;
+class CodegenContext;
+
+class TypeMatcher{
+public:
+    TypeMatcher(const CodegenContext& c) : ctx(c) {}
+
+    // Returns nullptr if no match or multiple matches, and writes corresponding
+    // errors to the parent context.
+    const OperatorEntry* MatchOperator(std::string name, Type t1, Type t2);
+
+    // TODO: Implement function overloading
+    // const FunctionEntry* MatchFunction(std::string name, std::list<Type> argtypes)
+private:
+    const CodegenContext& ctx;
+};
+}
+
+#endif // __TYPEMATCHER_H__

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -104,4 +104,9 @@ llvm::Value* ReferenceTypeAST::defaultLLVMsValue () const {
     return of()->defaultLLVMsValue();
 }
 
+bool TypeCmp::operator () (const Type& lhs,
+                           const Type& rhs) const {
+    return  lhs->gid() < rhs->gid();
+}
+
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -148,19 +148,9 @@ llvm::Value* BooleanTypeAST::defaultLLVMsValue () const {
     return llvm::ConstantInt::getFalse(getGlobalContext());
 }
 llvm::Value* ComplexTypeAST::defaultLLVMsValue () const {
-    auto v = dynamic_cast<llvm::Constant*>(
-    ctx_.getDoubleTy()->defaultLLVMsValue());
-    //const_cast<CodegenContext&>(ctx_).makeDouble(42)->codegen());
-    
+    auto v = dynamic_cast<llvm::Constant*>(ctx_.getDoubleTy()->defaultLLVMsValue());
     std::vector<llvm::Constant*> vek{v, v};
-    auto r = llvm::ConstantStruct::get(toLLVMs(), vek);
-    /*    std::cerr << "creating default complex, and r is ";
-    if(r)
-        r->dump();
-    else
-        std::cerr << "nullptr!";
-    std::cerr << std::endl;*/
-    return r;
+    return llvm::ConstantStruct::get(toLLVMs(), vek);
 }
 llvm::Value* ReferenceTypeAST::defaultLLVMsValue () const {
     return of()->defaultLLVMsValue();

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -109,4 +109,21 @@ bool TypeCmp::operator () (const Type& lhs,
     return  lhs->gid() < rhs->gid();
 }
 
+// ---------------------------------------------------------
+
+
+std::list<Conversion> IntegerTypeAST::ListConversions() const{
+    return {
+        Conversion{
+            ctx_.getDoubleTy(),   // Conversion to a double
+            10,                   // -- costs 10
+            [](CodegenContext & ctx, llvm::Value* v)->llvm::Value*{  // Note: The CodegenContext is passed again. We
+                                                                     // cannot reuse the parent context, because we
+                                                                     // need a non-const context.
+                return ctx.Builder.CreateSIToFP(v, llvm::Type::getDoubleTy(llvm::getGlobalContext()), "convtmp");
+            }
+        }
+    };
+}
+
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -148,9 +148,19 @@ llvm::Value* BooleanTypeAST::defaultLLVMsValue () const {
     return llvm::ConstantInt::getFalse(getGlobalContext());
 }
 llvm::Value* ComplexTypeAST::defaultLLVMsValue () const {
-    auto v = dynamic_cast<llvm::Constant*>(ctx_.getDoubleTy()->defaultLLVMsValue());
+    auto v = dynamic_cast<llvm::Constant*>(
+    //ctx_.getDoubleTy()->defaultLLVMsValue());
+    const_cast<CodegenContext&>(ctx_).makeDouble(42)->codegen());
+    
     std::vector<llvm::Constant*> vek{v, v};
-    return llvm::ConstantStruct::get(toLLVMs(), vek);
+    auto r = llvm::ConstantStruct::get(toLLVMs(), vek);
+        std::cerr << "creating default complex, and r is ";
+    if(r)
+        r->dump();
+    else
+        std::cerr << "nullptr!";
+    std::cerr << std::endl;
+    return r;
 }
 llvm::Value* ReferenceTypeAST::defaultLLVMsValue () const {
     return of()->defaultLLVMsValue();

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -182,13 +182,13 @@ std::list<Conversion> DoubleTypeAST::ListConversions() const{
     return {
         Conversion{
             ctx_.getComplexTy(),   // Conversion to complex
-            15,                   // -- costs 10
+            15,                   // -- costs 15
             [](CodegenContext & ctx, llvm::Value* v)->llvm::Value*{
                 llvm::Function *CalleeF = ctx.TheModule->getFunction("newComplex");
                 if(CalleeF) {
                     return ctx.Builder.CreateCall(CalleeF, {v, ctx.getDoubleTy()->defaultLLVMsValue()}, "callcmplxtmp");
                 } else {
-                    std::cerr << "newComplex not found!" << std::endl;
+                    ctx.AddError("newComplex constructor not found!");
                     return nullptr;
                 }
             }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -126,4 +126,18 @@ std::list<Conversion> IntegerTypeAST::ListConversions() const{
     };
 }
 
+std::list<Conversion> ReferenceTypeAST::ListConversions() const{
+    return {
+        Conversion{
+            of(),                // Conversion to the inner type
+            1,                   // -- costs 1
+            [](CodegenContext & ctx, llvm::Value* v)->llvm::Value*{
+                AllocaInst* alloca = dynamic_cast<AllocaInst*>(v);
+                if(!alloca) return nullptr;
+                return ctx.Builder.CreateLoad(alloca, v->getName() + "_load");
+            }
+        }
+    };
+}
+
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,5 +1,6 @@
 
 #include <typeinfo>
+#include <sstream>
 
 #include "types.h"
 #include "codegencontext.h"
@@ -13,6 +14,7 @@ template class Proxy<ArithmeticTypeAST>;
 template class Proxy<IntegerTypeAST>;
 template class Proxy<DoubleTypeAST>;
 template class Proxy<BooleanTypeAST>;
+template class Proxy<ComplexTypeAST>;
 template class Proxy<FunctionTypeAST>;
 template class Proxy<ReferenceTypeAST>;
 
@@ -25,6 +27,8 @@ Type str2type (const CodegenContext& ctx, std::string s) {
         return ctx.getDoubleTy();
     else if (s == "bool")
         return ctx.getBooleanTy();
+    else if (s == "complex")
+        return ctx.getComplexTy();
     else
         return ctx.getVoidTy();
 }
@@ -52,38 +56,81 @@ bool ReferenceTypeAST::equal (const TypeAST &other) const {
 
 // ---------------------------------------------------------
 
+std::string FunctionTypeAST::name() const {
+    std::ostringstream ss;
+    ss << "Function(";
+    if(size() > 1) {
+        size_t i = 1;
+        ss << argument(i)->name();
+        i++;
+        while(i < size()) {
+            ss << ", " << argument(i)->name();
+            i++;
+        }
+        ss << ") : " << returnType()->name();
+    }
+    return ss.str();
+}
+
+// ---------------------------------------------------------
+
 llvm::Type* TypeAST::toLLVMs () const {
     return nullptr;
 }
 
 llvm::Type* VoidTypeAST::toLLVMs () const {
-    return llvm::Type::getVoidTy(getGlobalContext());
+    if(!cache_)
+        cache_ = llvm::Type::getVoidTy(getGlobalContext());
+    return cache_;
 }
 
 llvm::Type* IntegerTypeAST::toLLVMs () const {
-    return llvm::Type::getInt32Ty(getGlobalContext());
+    if(!cache_)
+        cache_ = llvm::Type::getInt32Ty(getGlobalContext());
+    return cache_;
 }
 
 llvm::Type* DoubleTypeAST::toLLVMs () const {
-    return llvm::Type::getDoubleTy(getGlobalContext());
+    if(!cache_)
+        cache_ =  llvm::Type::getDoubleTy(getGlobalContext());
+    return cache_;
 }
 
 llvm::Type* BooleanTypeAST::toLLVMs () const {
-    return llvm::Type::getInt1Ty(getGlobalContext());
+    if(!cache_)
+        cache_ =  llvm::Type::getInt1Ty(getGlobalContext());
+    return cache_;
+}
+
+llvm::StructType* ComplexTypeAST::toLLVMs () const {
+    if(!cache_) {
+        auto dblt = ctx_.getDoubleTy()->toLLVMs();
+        cache_ = llvm::StructType::create(
+               getGlobalContext(),
+               {dblt, dblt},
+               name()
+        );
+    }
+    return llvm::dyn_cast<llvm::StructType>(cache_);
 }
 
 llvm::FunctionType* FunctionTypeAST::toLLVMs () const {
-    std::vector<llvm::Type*> argsTypes;
-    for (size_t i = 1; i < size(); i++)
-        argsTypes.push_back(operands_[i]->toLLVMs());
+    if(!cache_) {
+        std::vector<llvm::Type*> argsTypes;
+        for (size_t i = 1; i < size(); i++)
+            argsTypes.push_back(operands_[i]->toLLVMs());
 
-    return llvm::FunctionType::get(returnType()->toLLVMs(), argsTypes, false);
+        cache_ = llvm::FunctionType::get(returnType()->toLLVMs(), argsTypes, false);
+    }
+    return llvm::dyn_cast<llvm::FunctionType>(cache_);
 }
 
 llvm::Type* ReferenceTypeAST::toLLVMs () const {
     // will that be a pointer to of->toLLVMs() ? or just the of->toLLVMs()?
     // let's assume for now it's not a pointer
-    return of()->toLLVMs();
+    if(!cache_)
+        cache_ = of()->toLLVMs();
+    return cache_;
 }
 
 // ---------------------------------------------------------
@@ -99,6 +146,11 @@ llvm::Value* DoubleTypeAST::defaultLLVMsValue () const {
 }
 llvm::Value* BooleanTypeAST::defaultLLVMsValue () const {
     return llvm::ConstantInt::getFalse(getGlobalContext());
+}
+llvm::Value* ComplexTypeAST::defaultLLVMsValue () const {
+    auto v = dynamic_cast<llvm::Constant*>(ctx_.getDoubleTy()->defaultLLVMsValue());
+    std::vector<llvm::Constant*> vek{v, v};
+    return llvm::ConstantStruct::get(toLLVMs(), vek);
 }
 llvm::Value* ReferenceTypeAST::defaultLLVMsValue () const {
     return of()->defaultLLVMsValue();
@@ -121,6 +173,20 @@ std::list<Conversion> IntegerTypeAST::ListConversions() const{
                                                                      // cannot reuse the parent context, because we
                                                                      // need a non-const context.
                 return ctx.Builder.CreateSIToFP(v, llvm::Type::getDoubleTy(llvm::getGlobalContext()), "convtmp");
+            }
+        }
+    };
+}
+
+std::list<Conversion> DoubleTypeAST::ListConversions() const{
+    return {
+        Conversion{
+            ctx_.getComplexTy(),   // Conversion to complex
+            15,                   // -- costs 10
+            [](CodegenContext & ctx, llvm::Value* v)->llvm::Value*{
+                auto vc = dynamic_cast<llvm::Constant*>(v);
+                std::vector<llvm::Constant*> vek{vc, dynamic_cast<llvm::Constant*>(ctx.getDoubleTy()->defaultLLVMsValue())};
+                return llvm::ConstantStruct::get(ctx.getComplexTy()->toLLVMs(), vek);
             }
         }
     };

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -184,9 +184,13 @@ std::list<Conversion> DoubleTypeAST::ListConversions() const{
             ctx_.getComplexTy(),   // Conversion to complex
             15,                   // -- costs 10
             [](CodegenContext & ctx, llvm::Value* v)->llvm::Value*{
-                auto vc = dynamic_cast<llvm::Constant*>(v);
-                std::vector<llvm::Constant*> vek{vc, dynamic_cast<llvm::Constant*>(ctx.getDoubleTy()->defaultLLVMsValue())};
-                return llvm::ConstantStruct::get(ctx.getComplexTy()->toLLVMs(), vek);
+                llvm::Function *CalleeF = ctx.TheModule->getFunction("newComplex");
+                if(CalleeF) {
+                    return ctx.Builder.CreateCall(CalleeF, {v, ctx.getDoubleTy()->defaultLLVMsValue()}, "callcmplxtmp");
+                } else {
+                    std::cerr << "newComplex not found!" << std::endl;
+                    return nullptr;
+                }
             }
         }
     };

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -18,7 +18,7 @@ template class Proxy<ReferenceTypeAST>;
 
 using namespace llvm;
 
-Type str2type (CodegenContext& ctx, std::string s) {
+Type str2type (const CodegenContext& ctx, std::string s) {
     if (s == "int")
         return ctx.getIntegerTy();
     else if (s == "double")
@@ -36,7 +36,7 @@ bool TypeAST::equal (const TypeAST& other) const {
 bool FunctionTypeAST::equal (const TypeAST& other) const {
     if(size() != other.size())
         return false;
-    
+
     if(auto otherfun = other.isa<FunctionTypeAST>()) {
         for(size_t i = 0; i < size(); i++) {
             if(operand(i) != otherfun->operands_[i])
@@ -56,7 +56,7 @@ llvm::Type* TypeAST::toLLVMs () const {
     return nullptr;
 }
 
-llvm::Type* VoidTypeAST::toLLVMs () const { 
+llvm::Type* VoidTypeAST::toLLVMs () const {
     return llvm::Type::getVoidTy(getGlobalContext());
 }
 
@@ -68,7 +68,7 @@ llvm::Type* DoubleTypeAST::toLLVMs () const {
     return llvm::Type::getDoubleTy(getGlobalContext());
 }
 
-llvm::Type* BooleanTypeAST::toLLVMs () const { 
+llvm::Type* BooleanTypeAST::toLLVMs () const {
     return llvm::Type::getInt1Ty(getGlobalContext());
 }
 
@@ -76,7 +76,7 @@ llvm::FunctionType* FunctionTypeAST::toLLVMs () const {
     std::vector<llvm::Type*> argsTypes;
     for (size_t i = 1; i < size(); i++)
         argsTypes.push_back(operands_[i]->toLLVMs());
-    
+
     return llvm::FunctionType::get(returnType()->toLLVMs(), argsTypes, false);
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -149,17 +149,17 @@ llvm::Value* BooleanTypeAST::defaultLLVMsValue () const {
 }
 llvm::Value* ComplexTypeAST::defaultLLVMsValue () const {
     auto v = dynamic_cast<llvm::Constant*>(
-    //ctx_.getDoubleTy()->defaultLLVMsValue());
-    const_cast<CodegenContext&>(ctx_).makeDouble(42)->codegen());
+    ctx_.getDoubleTy()->defaultLLVMsValue());
+    //const_cast<CodegenContext&>(ctx_).makeDouble(42)->codegen());
     
     std::vector<llvm::Constant*> vek{v, v};
     auto r = llvm::ConstantStruct::get(toLLVMs(), vek);
-        std::cerr << "creating default complex, and r is ";
+    /*    std::cerr << "creating default complex, and r is ";
     if(r)
         r->dump();
     else
         std::cerr << "nullptr!";
-    std::cerr << std::endl;
+    std::cerr << std::endl;*/
     return r;
 }
 llvm::Value* ReferenceTypeAST::defaultLLVMsValue () const {

--- a/src/types.h
+++ b/src/types.h
@@ -29,106 +29,106 @@ class BooleanTypeAST;     using BooleanType     = Proxy<BooleanTypeAST>;
 class FunctionTypeAST;    using FunctionType    = Proxy<FunctionTypeAST>;
 class ReferenceTypeAST;   using ReferenceType   = Proxy<ReferenceTypeAST>;
 
-Type str2type (CodegenContext& ctx, std::string s);
+Type str2type (const CodegenContext& ctx, std::string s);
 
-class TypeAST : public MagicCast<TypeAST> { 
+class TypeAST : public MagicCast<TypeAST> {
 public:
-    TypeAST(CodegenContext& ctx, size_t gid, std::vector<Type> operands)
+    TypeAST(const CodegenContext& ctx, size_t gid, std::vector<Type> operands)
         : ctx_(ctx)
         , gid_(gid)
         , operands_(operands)
         , representative_(this)
     {}
     virtual ~TypeAST() {}
-    
+
     virtual bool equal (const TypeAST& other) const;
     virtual llvm::Type* toLLVMs () const;
     virtual llvm::Value* defaultLLVMsValue () const;
-    
+
     Type operand(size_t i) const { return operands_[i]; }
     size_t size() const { return operands_.size(); }
-    
-    CodegenContext& ctx () const { return ctx_; }
+
+    const CodegenContext& ctx () const { return ctx_; }
     size_t gid () const { return gid_; }
     bool is_proxy () const { return representative_ != this; }
-    
+
     bool operator < (const TypeAST& other) const { return gid() < other.gid(); }
-    
+
 protected:
-    CodegenContext& ctx_;
+    const CodegenContext& ctx_;
     size_t gid_;
     std::vector<Type> operands_;
     mutable const TypeAST* representative_;
-    
+
     template<class T> friend class Proxy;
 };
 
 class PrimitiveTypeAST : public TypeAST {
 public:
-    PrimitiveTypeAST(CodegenContext& ctx, size_t gid)
+    PrimitiveTypeAST(const CodegenContext& ctx, size_t gid)
         : TypeAST(ctx, gid, {})
     {}
 };
 
 class VoidTypeAST : public PrimitiveTypeAST {
 public:
-    VoidTypeAST(CodegenContext& ctx, size_t gid)
+    VoidTypeAST(const CodegenContext& ctx, size_t gid)
         : PrimitiveTypeAST(ctx, gid)
     {}
-    
+
     llvm::Type* toLLVMs () const override;
 };
 
 class ArithmeticTypeAST : public PrimitiveTypeAST {
 public:
-    ArithmeticTypeAST(CodegenContext& ctx, size_t gid)
+    ArithmeticTypeAST(const CodegenContext& ctx, size_t gid)
         : PrimitiveTypeAST(ctx, gid)
     {}
 };
 
 class IntegerTypeAST : public ArithmeticTypeAST {
 public:
-    IntegerTypeAST(CodegenContext& ctx, size_t gid)
+    IntegerTypeAST(const CodegenContext& ctx, size_t gid)
         : ArithmeticTypeAST(ctx, gid)
     {}
-    
+
     llvm::Type* toLLVMs () const override;
     llvm::Value* defaultLLVMsValue () const;
 };
 
 class DoubleTypeAST : public ArithmeticTypeAST {
 public:
-    DoubleTypeAST(CodegenContext& ctx, size_t gid)
+    DoubleTypeAST(const CodegenContext& ctx, size_t gid)
         : ArithmeticTypeAST(ctx, gid)
     {}
-    
+
     llvm::Type* toLLVMs () const override;
     llvm::Value* defaultLLVMsValue () const;
 };
 
 class BooleanTypeAST : public PrimitiveTypeAST {
 public:
-    BooleanTypeAST(CodegenContext& ctx, size_t gid)
+    BooleanTypeAST(const CodegenContext& ctx, size_t gid)
         : PrimitiveTypeAST(ctx, gid)
     {}
-    
+
     llvm::Type* toLLVMs () const override;
     llvm::Value* defaultLLVMsValue () const;
 };
 
 class FunctionTypeAST : public TypeAST {
 public:
-    FunctionTypeAST(CodegenContext& ctx, size_t gid, 
+    FunctionTypeAST(const CodegenContext& ctx, size_t gid,
                     Type ret, std::vector<Type> args)
         : TypeAST(ctx, gid, {})
     {
         args.insert(args.begin(), ret);
         operands_ = args;
     }
-    
+
     bool equal (const TypeAST& other) const override;
     llvm::FunctionType* toLLVMs () const override;
-    
+
     Type returnType () const { return operand(0); }
     // Mind you -- one-based argument list
     Type argument (size_t i) const { return operand(i); }
@@ -136,14 +136,14 @@ public:
 
 class ReferenceTypeAST : public TypeAST {
 public:
-    ReferenceTypeAST(CodegenContext& ctx, size_t gid, Type of)
+    ReferenceTypeAST(const CodegenContext& ctx, size_t gid, Type of)
         : TypeAST(ctx, gid, {of})
     {}
-    
+
     bool equal (const TypeAST& other) const override;
     llvm::Type* toLLVMs () const override;
     llvm::Value* defaultLLVMsValue () const;
-    
+
     Type of () const { return operand(0); }
 };
 

--- a/src/types.h
+++ b/src/types.h
@@ -9,10 +9,11 @@
 #include "llvm/IR/Module.h"
 
 #include "proxy.h"
-#include "cast.h"
+#include "conversions.h"
 
 #include <typeinfo>
 #include <vector>
+#include <list>
 #include <string>
 #include <unordered_set>
 
@@ -55,6 +56,10 @@ public:
 
     bool operator < (const TypeAST& other) const { return gid() < other.gid(); }
     virtual std::string name() const {return "NoType";}
+
+    virtual std::list<Conversion> ListConversions() const {
+        return std::list<Conversion>();
+    };
 
 protected:
     const CodegenContext& ctx_;
@@ -102,6 +107,8 @@ public:
     virtual std::string name() const {return "Integer";}
     llvm::Type* toLLVMs () const override;
     llvm::Value* defaultLLVMsValue () const;
+
+    virtual std::list<Conversion> ListConversions() const override;
 };
 
 class DoubleTypeAST : public ArithmeticTypeAST {

--- a/src/types.h
+++ b/src/types.h
@@ -158,12 +158,14 @@ public:
         : TypeAST(ctx, gid, {of})
     {}
 
-    virtual std::string name() const {return "Reference";}
+    virtual std::string name() const {return "ref(" + of().deref()->name() + ")";}
     bool equal (const TypeAST& other) const override;
     llvm::Type* toLLVMs () const override;
     llvm::Value* defaultLLVMsValue () const;
 
     Type of () const { return operand(0); }
+
+    virtual std::list<Conversion> ListConversions() const override;
 };
 
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -13,7 +13,7 @@ void CopyFile(std::string src, std::string dest);
 std::string SubstFileExt(std::string filename, std::string ext);
 
 std::vector<std::string> SplitString(std::string str, std::string delimiter);
-std::string JoinString(std::vector<std::string> str, std::string c);
+std::string JoinString(std::vector<std::string> str, std::string c = "");
 
 inline bool StringEndsWith(std::string const & value, std::string const & ending)
 {


### PR DESCRIPTION
This branch introduces initial support for implicit conversions.

I don't want to merge it just yet, I want you to review and see how do you like my solution. In particular, I am very unsure about my changes to Proxy (I don't get the nature of it!). I am also interested in how do you feel about my approach to extract type-resolution related code to a `TypeMatcher` class. Generally, let's merge it once we are both happy with this implementation.

This branch should enable us to perform implicit conversions. `./examples/implicit.cco` provides a simple testcase. Turns out currently we only have on kind of implicit conversion - that is int->double (I really dislike implicit boolean conversions). Adding new ones is as simple as providing a new entry to `TypeMatcher::InitImplicitConversions()`. The conversions can be performed with a llvm instruction, or, potentially, with a runtime library call (for complex types), and it should be just as simple!

What still needs to be done:
- Function overload resolution will use exactly the same logic as operator resolution, just slightly more generalized to more than 2 arguments. I cannot implement it just yet, as we do not use name-mangling yet.
- Transitive implicit conversions (eg. int->float->double) are unimplemented. I believe it's simple to add, though - turning map-lookup in `TypeMatcher::Inflate` into Dijkstra algorithm should be enough. No way to test it, though, until we have more conversions.
- The error displayed on multiple candidates match should be more verbose, but I cannot test it as we do not have enough types.

Note: maybe we might implement a `complex` number type. That would introduce some extra implicit conversions, and would provide a non-trivial type that is not represented by llvm and requires runtime library support for operations. Just a thought.
