### PR TITLE
Intended use of runtime library

### DIFF
--- a/common/common_types.h
+++ b/common/common_types.h
@@ -16,7 +16,6 @@ struct __cco_complex{
 } // extern "C"
 
 #include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/TypeBuilder.h"
 
 using namespace llvm;
 // LLVM Type definitions. Used to describe structures to LLVM.
@@ -27,14 +26,18 @@ template<typename T> inline llvm::StructType* __cco_type_to_LLVM();
 template<>
 inline llvm::StructType* __cco_type_to_LLVM<__cco_complex>(){
     auto double_type = llvm::Type::getDoubleTy(llvm::getGlobalContext());
-    auto t = llvm::StructType::get(
+    // NOTE: The following variable is static, because each call to
+    // ...::create introduces a new copy of the same type, which
+    // results in duplicate types (they are not uniqued).
+    static auto t = llvm::StructType::create(
        llvm::getGlobalContext(),
        {double_type, double_type},
-       "__cco_complex" // The name must be matching, too
+       "__cco_complex" // Let's keep the names matching the libcco type names
        );
     return t;
 }
 
+#include "llvm/IR/TypeBuilder.h"
 // LLVM TypeBuilder template specifications. Used to create LLVM structure types on compile-time (see http://llvm.org/docs/doxygen/html/classllvm_1_1TypeBuilder.html).
 
 namespace llvm {
@@ -46,6 +49,6 @@ namespace llvm {
     };
 }  // namespace llvm
 
-#endif
+#endif // ifdef __cplusplus
 
 #endif // __COMMON_TYPES_H__

--- a/common/common_types.h
+++ b/common/common_types.h
@@ -1,0 +1,51 @@
+#ifndef __COMMON_TYPES_H__
+#define __COMMON_TYPES_H__
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+// ANSI C definitions. Used to compile the runtime library.
+
+struct __cco_complex{
+    double re;
+    double im;
+};
+
+#ifdef __cplusplus
+} // extern "C"
+
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/TypeBuilder.h"
+
+using namespace llvm;
+// LLVM Type definitions. Used to describe structures to LLVM.
+// These must perfectly match corresponding C types.
+
+template<typename T> inline llvm::StructType* __cco_type_to_LLVM();
+
+template<>
+inline llvm::StructType* __cco_type_to_LLVM<__cco_complex>(){
+    auto double_type = llvm::Type::getDoubleTy(llvm::getGlobalContext());
+    auto t = llvm::StructType::get(
+       llvm::getGlobalContext(),
+       {double_type, double_type},
+       "__cco_complex" // The name must be matching, too
+       );
+    return t;
+}
+
+// LLVM TypeBuilder template specifications. Used to create LLVM structure types on compile-time (see http://llvm.org/docs/doxygen/html/classllvm_1_1TypeBuilder.html).
+
+namespace llvm {
+    template<bool xcompile> class TypeBuilder<__cco_complex, xcompile> {
+    public:
+        static StructType *get(LLVMContext &Context) {
+            return __cco_type_to_LLVM<__cco_complex>();
+        }
+    };
+}  // namespace llvm
+
+#endif
+
+#endif // __COMMON_TYPES_H__

--- a/examples/complex2.cco
+++ b/examples/complex2.cco
@@ -16,11 +16,11 @@ fun main() : int {
     var i : int;
     var c : complex;
     var d : complex;
-    
+
     c := newComplex(3, -2);
     d := foo(-2, c);
     print(d);
     d := bar(3, 0.14);
     print(d);
-    print(bar(3, 0.14));
+    print(bar(3, 0.14) * 3.0);
 }

--- a/examples/complex3.cco
+++ b/examples/complex3.cco
@@ -1,7 +1,4 @@
-
-
 fun main() : int {
     var c : complex;
     c := newComplex(5.0, 9.0);
-
 }

--- a/examples/complex3.cco
+++ b/examples/complex3.cco
@@ -1,0 +1,7 @@
+
+
+fun main() : int {
+    var c : complex;
+    c := newComplex(5.0, 9.0);
+
+}

--- a/libcco/complex.c
+++ b/libcco/complex.c
@@ -28,6 +28,13 @@ struct __cco_complex __cco_complex_mult(struct __cco_complex a,
     c.im = a.im*b.re + a.re*b.im;
     return c;
 }
+struct __cco_complex __cco_complex_mult_double(struct __cco_complex a,
+                                               double b){
+    struct __cco_complex c;
+    c.re = a.re*b;
+    c.im = a.im*b;
+    return c;
+}
 struct __cco_complex __cco_complex_div(struct __cco_complex a,
                                        struct __cco_complex b){
     struct __cco_complex c;

--- a/libcco/complex.c
+++ b/libcco/complex.c
@@ -1,0 +1,51 @@
+#include "complex.h"
+
+struct __cco_complex __cco_complex_new(double re, double im){
+    struct __cco_complex c;
+    c.re = re;
+    c.im = im;
+    return c;
+}
+
+struct __cco_complex __cco_complex_add(struct __cco_complex a,
+                                       struct __cco_complex b){
+    struct __cco_complex c;
+    c.re = a.re + b.re;
+    c.im = a.im + b.im;
+    return c;
+}
+struct __cco_complex __cco_complex_sub(struct __cco_complex a,
+                                       struct __cco_complex b){
+    struct __cco_complex c;
+    c.re = a.re - b.re;
+    c.im = a.im - b.im;
+    return c;
+}
+struct __cco_complex __cco_complex_mult(struct __cco_complex a,
+                                        struct __cco_complex b){
+    struct __cco_complex c;
+    c.re = a.re*b.re - a.im*b.im;
+    c.im = a.im*b.re + a.re*b.im;
+    return c;
+}
+struct __cco_complex __cco_complex_div(struct __cco_complex a,
+                                       struct __cco_complex b){
+    struct __cco_complex c;
+    double sumsq = b.re*b.re + b.im*b.im;
+    double re = a.re*b.re + a.im*b.im;
+    double im = a.im*b.re - a.re*b.im;
+    c.re = re/sumsq;
+    c.im = im/sumsq;
+    return c;
+}
+struct __cco_complex __cco_complex_div_double(struct __cco_complex a,
+                                              double b){
+    struct __cco_complex c;
+    c.re = a.re/b;
+    c.im = a.im/b;
+    return c;
+}
+int __cco_complex_equal(struct __cco_complex a,
+                         struct __cco_complex b){
+    return a.re == b.re && a.im == b.im;
+}

--- a/libcco/complex.c
+++ b/libcco/complex.c
@@ -28,13 +28,6 @@ struct __cco_complex __cco_complex_mult(struct __cco_complex a,
     c.im = a.im*b.re + a.re*b.im;
     return c;
 }
-struct __cco_complex __cco_complex_mult_double(struct __cco_complex a,
-                                               double b){
-    struct __cco_complex c;
-    c.re = a.re*b;
-    c.im = a.im*b;
-    return c;
-}
 struct __cco_complex __cco_complex_div(struct __cco_complex a,
                                        struct __cco_complex b){
     struct __cco_complex c;
@@ -43,13 +36,6 @@ struct __cco_complex __cco_complex_div(struct __cco_complex a,
     double im = a.im*b.re - a.re*b.im;
     c.re = re/sumsq;
     c.im = im/sumsq;
-    return c;
-}
-struct __cco_complex __cco_complex_div_double(struct __cco_complex a,
-                                              double b){
-    struct __cco_complex c;
-    c.re = a.re/b;
-    c.im = a.im/b;
     return c;
 }
 int __cco_complex_equal(struct __cco_complex a,

--- a/libcco/complex.c
+++ b/libcco/complex.c
@@ -28,6 +28,13 @@ struct __cco_complex __cco_complex_mult(struct __cco_complex a,
     c.im = a.im*b.re + a.re*b.im;
     return c;
 }
+struct __cco_complex __cco_complex_mult_double(struct __cco_complex a,
+                                               double b){
+    struct __cco_complex c;
+    c.re = a.re*b;
+    c.im = a.im*b;
+    return c;
+}
 struct __cco_complex __cco_complex_div(struct __cco_complex a,
                                        struct __cco_complex b){
     struct __cco_complex c;
@@ -36,6 +43,13 @@ struct __cco_complex __cco_complex_div(struct __cco_complex a,
     double im = a.im*b.re - a.re*b.im;
     c.re = re/sumsq;
     c.im = im/sumsq;
+    return c;
+}
+struct __cco_complex __cco_complex_div_double(struct __cco_complex a,
+                                              double b){
+    struct __cco_complex c;
+    c.re = a.re/b;
+    c.im = a.im/b;
     return c;
 }
 int __cco_complex_equal(struct __cco_complex a,

--- a/libcco/complex.h
+++ b/libcco/complex.h
@@ -1,0 +1,22 @@
+#ifndef __COMPLEX_H__
+#define __COMPLEX_H__
+
+#include "../common/common_types.h"
+
+struct __cco_complex __cco_complex_new(double, double);
+
+struct __cco_complex __cco_complex_add(struct __cco_complex,
+                                       struct __cco_complex);
+struct __cco_complex __cco_complex_sub(struct __cco_complex,
+                                       struct __cco_complex);
+struct __cco_complex __cco_complex_mult(struct __cco_complex,
+                                        struct __cco_complex);
+struct __cco_complex __cco_complex_div(struct __cco_complex,
+                                       struct __cco_complex);
+struct __cco_complex __cco_complex_div_double(struct __cco_complex,
+                                              double);
+
+int __cco_complex_equal(struct __cco_complex,
+                        struct __cco_complex);
+
+#endif // __COMPLEX_H__

--- a/libcco/complex.h
+++ b/libcco/complex.h
@@ -11,13 +11,8 @@ struct __cco_complex __cco_complex_sub(struct __cco_complex,
                                        struct __cco_complex);
 struct __cco_complex __cco_complex_mult(struct __cco_complex,
                                         struct __cco_complex);
-struct __cco_complex __cco_complex_mult_double(struct __cco_complex,
-                                               double);
 struct __cco_complex __cco_complex_div(struct __cco_complex,
                                        struct __cco_complex);
-struct __cco_complex __cco_complex_div_double(struct __cco_complex,
-                                              double);
-
 int __cco_complex_equal(struct __cco_complex,
                         struct __cco_complex);
 

--- a/libcco/complex.h
+++ b/libcco/complex.h
@@ -11,6 +11,8 @@ struct __cco_complex __cco_complex_sub(struct __cco_complex,
                                        struct __cco_complex);
 struct __cco_complex __cco_complex_mult(struct __cco_complex,
                                         struct __cco_complex);
+struct __cco_complex __cco_complex_mult_double(struct __cco_complex,
+                                               double);
 struct __cco_complex __cco_complex_div(struct __cco_complex,
                                        struct __cco_complex);
 struct __cco_complex __cco_complex_div_double(struct __cco_complex,

--- a/libcco/complex.h
+++ b/libcco/complex.h
@@ -11,8 +11,13 @@ struct __cco_complex __cco_complex_sub(struct __cco_complex,
                                        struct __cco_complex);
 struct __cco_complex __cco_complex_mult(struct __cco_complex,
                                         struct __cco_complex);
+struct __cco_complex __cco_complex_mult_double(struct __cco_complex,
+                                               double);
 struct __cco_complex __cco_complex_div(struct __cco_complex,
                                        struct __cco_complex);
+struct __cco_complex __cco_complex_div_double(struct __cco_complex,
+                                              double);
+
 int __cco_complex_equal(struct __cco_complex,
                         struct __cco_complex);
 

--- a/libcco/print.c
+++ b/libcco/print.c
@@ -16,6 +16,6 @@ void __cco_print_cstr(char* v) {
     printf("%s\n", v);
 }
 
-void __cco_print_complex(double re, double im) {
-    printf("Complex[Re = %f; Im = %f]\n", re, im);
+void __cco_print_complex(struct __cco_complex c){
+    printf("Complex[Re = %f; Im = %f]\n", c.re, c.im);
 }

--- a/libcco/print.h
+++ b/libcco/print.h
@@ -12,4 +12,5 @@ void __cco_print_bool(int);
 void __cco_print_cstr(char*);
 void __cco_print_complex(struct __cco_complex);
 
+
 #endif // __CCO_PRINT_H__

--- a/libcco/print.h
+++ b/libcco/print.h
@@ -1,5 +1,6 @@
 #ifndef __CCO_PRINT_H__
 #define __CCO_PRINT_H__
+#include "../common/common_types.h"
 
 // Eventually, these definitions will have to be wrapped in macros, so
 // that they can either define these functions, or unwrap into a C++
@@ -9,6 +10,6 @@ void __cco_print_int(int);
 void __cco_print_double(double);
 void __cco_print_bool(int);
 void __cco_print_cstr(char*);
-void __cco_print_complex(double, double);
+void __cco_print_complex(struct __cco_complex);
 
 #endif // __CCO_PRINT_H__

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -374,12 +374,7 @@ void CodegenContext::PrepareStdFunctionPrototypes_(){
     ADD_STDPROTO("print_bool",void(llvm::types::i<1>));
     ADD_STDPROTO("print_cstr", void(char*));
     ADD_STDPROTO("print_complex", void(__cco_complex));
-
-    auto complexproto = makePrototype(
-        "newComplex", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getComplexTy());
-    makeFunction(complexproto, makeBlock({makeVariableDecl("Cmplx", getComplexTy()),
-        makeReturn(makeComplex(makeVariableOcc("Re"), makeVariableOcc("Im")))})
-        );
+    ADD_STDPROTO("complex_new", __cco_complex(double, double));
 }
 
 }

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -99,7 +99,9 @@ CodegenContext::CodegenContext()
     ADD_STD_OP("ADD" , getComplexTy(), getComplexTy(), "complex_add" , getComplexTy(), "complexadd" );
     ADD_STD_OP("SUB" , getComplexTy(), getComplexTy(), "complex_sub" , getComplexTy(), "complexsub" );
     ADD_STD_OP("MULT", getComplexTy(), getComplexTy(), "complex_mult", getComplexTy(), "complexmult");
+    ADD_STD_OP("MULT", getComplexTy(), getDoubleTy(), "complex_mult_double", getComplexTy(), "complexmult");
     ADD_STD_OP("DIV" , getComplexTy(), getComplexTy(), "complex_div" , getComplexTy(), "complexdiv" );
+    ADD_STD_OP("DIV" , getComplexTy(), getDoubleTy(), "complex_div_double" , getComplexTy(), "complexdiv" );
     ADD_STD_OP("EQUAL" , getComplexTy(), getComplexTy(), "complex_equal" , getBooleanTy(), "complexeq" );
 
 }
@@ -335,7 +337,9 @@ void CodegenContext::PrepareStdFunctionPrototypes_(){
     ADD_STDPROTO("complex_add" , __cco_complex(__cco_complex,__cco_complex));
     ADD_STDPROTO("complex_sub" , __cco_complex(__cco_complex,__cco_complex));
     ADD_STDPROTO("complex_mult", __cco_complex(__cco_complex,__cco_complex));
+    ADD_STDPROTO("complex_mult_double", __cco_complex(__cco_complex,double));
     ADD_STDPROTO("complex_div" , __cco_complex(__cco_complex,__cco_complex));
+    ADD_STDPROTO("complex_div_double" , __cco_complex(__cco_complex,double));
     ADD_STDPROTO("complex_equal" , llvm::types::i<1>(__cco_complex,__cco_complex));
 }
 

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -99,9 +99,7 @@ CodegenContext::CodegenContext()
     ADD_STD_OP("ADD" , getComplexTy(), getComplexTy(), "complex_add" , getComplexTy(), "complexadd" );
     ADD_STD_OP("SUB" , getComplexTy(), getComplexTy(), "complex_sub" , getComplexTy(), "complexsub" );
     ADD_STD_OP("MULT", getComplexTy(), getComplexTy(), "complex_mult", getComplexTy(), "complexmult");
-    ADD_STD_OP("MULT", getComplexTy(), getDoubleTy(), "complex_mult_double", getComplexTy(), "complexmult");
     ADD_STD_OP("DIV" , getComplexTy(), getComplexTy(), "complex_div" , getComplexTy(), "complexdiv" );
-    ADD_STD_OP("DIV" , getComplexTy(), getDoubleTy(), "complex_div_double" , getComplexTy(), "complexdiv" );
     ADD_STD_OP("EQUAL" , getComplexTy(), getComplexTy(), "complex_equal" , getBooleanTy(), "complexeq" );
 
 }
@@ -337,9 +335,7 @@ void CodegenContext::PrepareStdFunctionPrototypes_(){
     ADD_STDPROTO("complex_add" , __cco_complex(__cco_complex,__cco_complex));
     ADD_STDPROTO("complex_sub" , __cco_complex(__cco_complex,__cco_complex));
     ADD_STDPROTO("complex_mult", __cco_complex(__cco_complex,__cco_complex));
-    ADD_STDPROTO("complex_mult_double", __cco_complex(__cco_complex,double));
     ADD_STDPROTO("complex_div" , __cco_complex(__cco_complex,__cco_complex));
-    ADD_STDPROTO("complex_div_double" , __cco_complex(__cco_complex,double));
     ADD_STDPROTO("complex_equal" , llvm::types::i<1>(__cco_complex,__cco_complex));
 }
 

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -2,6 +2,9 @@
 #include "utils.h"
 #include <iostream>
 
+#include "../common/common_types.h"
+
+
 namespace ccoscope {
 
 using namespace std;
@@ -22,7 +25,7 @@ CodegenContext::CodegenContext()
         [this] (std::vector<Value*> v) { \
             return this->builder_.builderfunc(v[0], v[1], retname);\
        }
-       
+
 #define ADD_ASSIGN_OP(t) \
     availableBinOps_["ASSIGN"].push_back(MatchCandidateEntry{{getReferenceTy(t), t}, getVoidTy()}); \
     binOpCreator_[{"ASSIGN", MatchCandidateEntry{{getReferenceTy(t), t}, getVoidTy()}}] = \
@@ -45,25 +48,25 @@ CodegenContext::CodegenContext()
     INIT_OP("LOGICAL_AND");
     INIT_OP("LOGICAL_OR");
     INIT_OP("ASSIGN");
-    
+
     ADD_ASSIGN_OP(getIntegerTy());
     ADD_ASSIGN_OP(getBooleanTy());
     ADD_ASSIGN_OP(getDoubleTy());
     ADD_ASSIGN_OP(getComplexTy());
-    
+
     ADD_BASIC_OP("ADD",    getIntegerTy(), getIntegerTy(), CreateAdd,  getIntegerTy(), "addtmp");
     ADD_BASIC_OP("SUB",    getIntegerTy(), getIntegerTy(), CreateSub,  getIntegerTy(), "subtmp");
     ADD_BASIC_OP("MULT",   getIntegerTy(), getIntegerTy(), CreateMul,  getIntegerTy(), "multmp");
     ADD_BASIC_OP("DIV",    getIntegerTy(), getIntegerTy(), CreateSDiv, getIntegerTy(), "divtmp");
     ADD_BASIC_OP("MOD",    getIntegerTy(), getIntegerTy(), CreateSRem, getIntegerTy(), "modtmp");
-    
+
     ADD_BASIC_OP("EQUAL",    getIntegerTy(), getIntegerTy(), CreateICmpEQ,  getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("NEQUAL",   getIntegerTy(), getIntegerTy(), CreateICmpNE,  getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("GREATER",  getIntegerTy(), getIntegerTy(), CreateICmpSGT, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("GREATEREQ",getIntegerTy(), getIntegerTy(), CreateICmpSGE, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("LESS",     getIntegerTy(), getIntegerTy(), CreateICmpSLT, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("LESSEQ",   getIntegerTy(), getIntegerTy(), CreateICmpSLE, getBooleanTy(), "cmptmp");
-    
+
     ADD_BASIC_OP("LOGICAL_AND", getBooleanTy(), getBooleanTy(), CreateAnd,  getBooleanTy(), "andtmp");
     ADD_BASIC_OP("LOGICAL_OR" , getBooleanTy(), getBooleanTy(), CreateOr,   getBooleanTy(), "ortmp" );
 
@@ -79,7 +82,7 @@ CodegenContext::CodegenContext()
     ADD_BASIC_OP("GREATEREQ",getDoubleTy(), getDoubleTy(), CreateFCmpOGE, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("LESS",     getDoubleTy(), getDoubleTy(), CreateFCmpOLT, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("LESSEQ",   getDoubleTy(), getDoubleTy(), CreateFCmpOLE, getBooleanTy(), "cmptmp");
-    
+
 #define ADD_COMPLEX_OP(name, variadiccode, rettype, retname) \
     availableBinOps_[name].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()}, rettype}); \
     binOpCreator_[{name, MatchCandidateEntry{{getComplexTy(), getComplexTy()}, rettype}}] = \
@@ -131,7 +134,7 @@ CodegenContext::CodegenContext()
             auto reres = this->builder_.CreateFDiv(left, squares, "cmplxdivtmp");
             auto imres = this->builder_.CreateFDiv(right, squares, "cmplxdivtmp");
      , getComplexTy(), "divtmp");
-    
+
     availableBinOps_["EQUAL"].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()}, getBooleanTy()});
     binOpCreator_[{"EQUAL", MatchCandidateEntry{{getComplexTy(), getComplexTy()}, getBooleanTy()}}] =
        [this] (std::vector<Value*> v){
@@ -370,7 +373,7 @@ void CodegenContext::PrepareStdFunctionPrototypes_(){
     ADD_STDPROTO("print_double",void(double));
     ADD_STDPROTO("print_bool",void(llvm::types::i<1>));
     ADD_STDPROTO("print_cstr", void(char*));
-    ADD_STDPROTO("print_complex", void(double, double));
+    ADD_STDPROTO("print_complex", void(__cco_complex));
 
     auto complexproto = makePrototype(
         "newComplex", {{"Re", getDoubleTy()}, {"Im", getDoubleTy()}}, getComplexTy());

--- a/src/codegencontext.cpp
+++ b/src/codegencontext.cpp
@@ -4,7 +4,6 @@
 
 #include "../common/common_types.h"
 
-
 namespace ccoscope {
 
 using namespace std;
@@ -83,69 +82,28 @@ CodegenContext::CodegenContext()
     ADD_BASIC_OP("LESS",     getDoubleTy(), getDoubleTy(), CreateFCmpOLT, getBooleanTy(), "cmptmp");
     ADD_BASIC_OP("LESSEQ",   getDoubleTy(), getDoubleTy(), CreateFCmpOLE, getBooleanTy(), "cmptmp");
 
-#define ADD_COMPLEX_OP(name, variadiccode, rettype, retname) \
-    availableBinOps_[name].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()}, rettype}); \
-    binOpCreator_[{name, MatchCandidateEntry{{getComplexTy(), getComplexTy()}, rettype}}] = \
-       [this] (std::vector<Value*> v){   \
-            auto c1re = this->builder_.CreateExtractValue(v[0], {0}); \
-            auto c1im = this->builder_.CreateExtractValue(v[0], {1}); \
-            auto c2re = this->builder_.CreateExtractValue(v[1], {0}); \
-            auto c2im = this->builder_.CreateExtractValue(v[1], {1}); \
-            variadiccode \
-            auto cmplx_t = getComplexTy()->toLLVMs(); \
-            AllocaInst* alloca = CreateEntryBlockAlloca(CurrentFunc(), "cmplxtmp", cmplx_t); \
-            auto idx1 = this->builder_.CreateStructGEP(cmplx_t, alloca, 0); \
-            this->builder_.CreateStore(reres, idx1); \
-            auto idx2 = this->builder_.CreateStructGEP(cmplx_t, alloca, 1); \
-            this->builder_.CreateStore(imres, idx2); \
-            auto retsload = this->builder_.CreateLoad(alloca, "Cmplxloadret"); \
-            return retsload; \
-       }
+    // This macro is useful for creating operators that use a libcco
+    // function. NOTE: There are no checks whether the requested
+    // stdfunction has a registered prototype, or whether the
+    // arguments are of correct type. As long as the prototypes and
+    // match types are correctly implemented, there will be no runtime
+    // errors.
+#define ADD_STD_OP(name, t1, t2, opfunc, rettype, retname)              \
+    availableBinOps_[name].push_back(MatchCandidateEntry{{t1, t2}, rettype}); \
+    binOpCreator_[{name, MatchCandidateEntry{{t1, t2}, rettype}}] =    \
+        [this] (std::vector<Value*> v) -> Value*{                       \
+        llvm::Function* f = this->GetStdFunction(opfunc);        \
+        return this->Builder().CreateCall(f, v, retname);          \
+    };
 
-    ADD_COMPLEX_OP("ADD",
-            auto reres = this->builder_.CreateFAdd(c1re, c2re, "cmplxaddtmp");
-            auto imres = this->builder_.CreateFAdd(c1im, c2im, "cmplxaddtmp");
-     , getComplexTy(), "addtmp");
+    ADD_STD_OP("ADD" , getComplexTy(), getComplexTy(), "complex_add" , getComplexTy(), "complexadd" );
+    ADD_STD_OP("SUB" , getComplexTy(), getComplexTy(), "complex_sub" , getComplexTy(), "complexsub" );
+    ADD_STD_OP("MULT", getComplexTy(), getComplexTy(), "complex_mult", getComplexTy(), "complexmult");
+    ADD_STD_OP("MULT", getComplexTy(), getDoubleTy(), "complex_mult_double", getComplexTy(), "complexmult");
+    ADD_STD_OP("DIV" , getComplexTy(), getComplexTy(), "complex_div" , getComplexTy(), "complexdiv" );
+    ADD_STD_OP("DIV" , getComplexTy(), getDoubleTy(), "complex_div_double" , getComplexTy(), "complexdiv" );
+    ADD_STD_OP("EQUAL" , getComplexTy(), getComplexTy(), "complex_equal" , getBooleanTy(), "complexeq" );
 
-    ADD_COMPLEX_OP("SUB",
-            auto reres = this->builder_.CreateFSub(c1re, c2re, "cmplxsubtmp");
-            auto imres = this->builder_.CreateFSub(c1im, c2im, "cmplxsubtmp");
-     , getComplexTy(), "subtmp");
-
-    ADD_COMPLEX_OP("MULT",
-            auto c1c2re = this->builder_.CreateFMul(c1re, c2re, "cmplxmultmp");
-            auto c1c2im = this->builder_.CreateFMul(c1im, c2im, "cmplxmultmp");
-            auto c1imc2re = this->builder_.CreateFMul(c1im, c2re, "cmplxmultmp");
-            auto c1rec2im = this->builder_.CreateFMul(c1re, c2im, "cmplxmultmp");
-            auto reres = this->builder_.CreateFSub(c1c2re, c1c2im, "cmplxsubtmp");
-            auto imres = this->builder_.CreateFAdd(c1imc2re, c1rec2im, "cmplxaddtmp");
-     , getComplexTy(), "multmp");
-
-    ADD_COMPLEX_OP("DIV",
-            auto c1c2re = this->builder_.CreateFMul(c1re, c2re, "cmplxmultmp");
-            auto c1c2im = this->builder_.CreateFMul(c1im, c2im, "cmplxmultmp");
-            auto c1imc2re = this->builder_.CreateFMul(c1im, c2re, "cmplxmultmp");
-            auto c1rec2im = this->builder_.CreateFMul(c1re, c2im, "cmplxmultmp");
-            auto c2rere = this->builder_.CreateFMul(c2re, c2re, "cmplxmultmp");
-            auto c2imim = this->builder_.CreateFMul(c2im, c2im, "cmplxmultmp");
-            auto squares = this->builder_.CreateFAdd(c2rere, c2imim, "cmplxaddtmp");
-            auto left = this->builder_.CreateFAdd(c1c2re, c1c2im, "cmplxsubtmp");
-            auto right = this->builder_.CreateFSub(c1imc2re, c1rec2im, "cmplxaddtmp");
-            auto reres = this->builder_.CreateFDiv(left, squares, "cmplxdivtmp");
-            auto imres = this->builder_.CreateFDiv(right, squares, "cmplxdivtmp");
-     , getComplexTy(), "divtmp");
-
-    availableBinOps_["EQUAL"].push_back(MatchCandidateEntry{{getComplexTy(), getComplexTy()}, getBooleanTy()});
-    binOpCreator_[{"EQUAL", MatchCandidateEntry{{getComplexTy(), getComplexTy()}, getBooleanTy()}}] =
-       [this] (std::vector<Value*> v){
-            auto c1re = this->builder_.CreateExtractValue(v[0], {0});
-            auto c1im = this->builder_.CreateExtractValue(v[0], {1});
-            auto c2re = this->builder_.CreateExtractValue(v[1], {0});
-            auto c2im = this->builder_.CreateExtractValue(v[1], {1});
-            auto c1c2re = this->builder_.CreateFCmpOEQ(c1re, c2re, "cmplxcmptmp");
-            auto c1c2im = this->builder_.CreateFCmpOEQ(c1im, c2im, "cmplxcmptmp");
-            return this->builder_.CreateAnd(c1c2re, c1c2im, "cmplxcmptmp");
-       };
 }
 
 CodegenContext::~CodegenContext() {
@@ -374,7 +332,15 @@ void CodegenContext::PrepareStdFunctionPrototypes_(){
     ADD_STDPROTO("print_bool",void(llvm::types::i<1>));
     ADD_STDPROTO("print_cstr", void(char*));
     ADD_STDPROTO("print_complex", void(__cco_complex));
-    ADD_STDPROTO("complex_new", __cco_complex(double, double));
+
+    ADD_STDPROTO("complex_new" , __cco_complex(double, double));
+    ADD_STDPROTO("complex_add" , __cco_complex(__cco_complex,__cco_complex));
+    ADD_STDPROTO("complex_sub" , __cco_complex(__cco_complex,__cco_complex));
+    ADD_STDPROTO("complex_mult", __cco_complex(__cco_complex,__cco_complex));
+    ADD_STDPROTO("complex_mult_double", __cco_complex(__cco_complex,double));
+    ADD_STDPROTO("complex_div" , __cco_complex(__cco_complex,__cco_complex));
+    ADD_STDPROTO("complex_div_double" , __cco_complex(__cco_complex,double));
+    ADD_STDPROTO("complex_equal" , llvm::types::i<1>(__cco_complex,__cco_complex));
 }
 
 }

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -2,6 +2,7 @@
 #include "codegencontext.h"
 
 #include "llvm/IR/Verifier.h"
+#include "llvm/IR/Value.h"
 
 #define DEBUG 0
 

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -642,10 +642,6 @@ Type CallExprAST::Typecheck_() const {
             BestOverload = ctx().GetStdFunction("complex_new");
             return match.match.return_type;
         }
-
-
-
-
     }// if callee == print
 
     // Find a a corresponding candidate.

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -642,6 +642,10 @@ Type CallExprAST::Typecheck_() const {
             BestOverload = ctx().GetStdFunction("complex_new");
             return match.match.return_type;
         }
+
+
+
+
     }// if callee == print
 
     // Find a a corresponding candidate.

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -4,6 +4,7 @@
 
 #include "types.h"
 #include "codegencontext.h"
+#include "../common/common_types.h"
 
 namespace ccoscope {
 
@@ -116,13 +117,7 @@ llvm::Type* BooleanTypeAST::toLLVMs_ () const {
 }
 
 llvm::StructType* ComplexTypeAST::toLLVMs_ () const {
-    auto dblt = ctx_.getDoubleTy()->toLLVMs();
-    auto t = llvm::StructType::create(
-       getGlobalContext(),
-       {dblt, dblt},
-       name()
-    );
-    return llvm::cast<llvm::StructType>(t);
+    return __cco_type_to_LLVM<__cco_complex>();
 }
 
 llvm::FunctionType* FunctionTypeAST::toLLVMs_ () const {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -178,7 +178,7 @@ std::list<Conversion> DoubleTypeAST::ListConversions() const{
             ctx_.getComplexTy(),   // Conversion to complex
             15,                   // -- costs 15
             [this](llvm::Value* v)->llvm::Value*{
-                llvm::Function *CalleeF = this->ctx().TheModule()->getFunction("newComplex");
+                llvm::Function *CalleeF = this->ctx().GetStdFunction("complex_new");
                 if(CalleeF) {
                     return this->ctx().Builder().CreateCall(CalleeF, {v, this->ctx().getDoubleTy()->defaultLLVMsValue()}, "callcmplxtmp");
                 } else {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -23,8 +23,9 @@ std::string GetTmpFile(std::string suffix){
 std::string GetExecutablePath(){
     // The trick is to read what file the link /proc/self/exe points to.
     // This is obviously not portable.
-    char buffer[260];
-    readlink("/proc/self/exe",buffer,260);
+    char buffer[500];
+    int n = readlink("/proc/self/exe",buffer,500);
+    buffer[n] = 0;
     std::string path(buffer);
     auto pos = path.rfind('/');
     return path.substr(0,pos+1);


### PR DESCRIPTION
This branch moves complex type operations from LLVM builder calls to the runtime library. This significantly cleans up the source, and provides an example for implementing other complex types (eg. a string).

The highlights of this branch are:
- `libcco/complex.cpp` - now contains all complex operations expressed in plain, readable C. Easily maintainable!
- `CodegenContext::CodegenContext()` - got much shorter and no longer has those huge lambdas that manually multiply doubles that make a complex. All it does now is specifying which libcco function corresponds to which operator, and what are it's input and return types.
- The `newComplex` function was stripped. It is still accepted in-language for creating new complex values, but during compilation it gets translated to a call to `__cco_complex_new`. This solves #26.
- `common/common_types.h` is used by both `CCoscope` and `libcco`, and provides an uniform description of runtime types used by programs generated by CCoscope.

While testing this branch, I found a critical problem on a 32-bit system: the calling convention of `llc`-generated assembly did not match the calling convention used by `libcco` internally. I am now almost certain that it was caused by an incorrectly installed llvm on that system, but we may want to double-check that there are no such problems on 32-bit machines. The llvm documentation claims that by default llvm uses C calling convention, which should be compatible even with gcc generated binaries.
